### PR TITLE
Updating composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,8 @@
   "name": "convertkit/convertkitapi",
   "description": "ConvertKit API SDK",
   "keywords": ["convertkit", "api", "forms"],
-  "version": "0.0.1",
   "require": {
-    "php": ">=5.3.0",
+    "php": ">=5.5",
     "guzzlehttp/guzzle": "^6.3",
     "monolog/monolog": "^1.0"
   },
@@ -19,5 +18,6 @@
       "src/"
     ]
   },
-  "minimum-stability": "dev"
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
       "ConvertKit_API\\": "src/"
     },
     "classmap": [
-      "src/"
+      "src/lib/"
     ]
   },
   "minimum-stability": "dev",


### PR DESCRIPTION
1. Removed version in composer, in the hopes that the project can use
tags
2. Prefer stable for packages it pulls in
3. PHP min version updated to 5.5 as included project Guzzle 6.3 requires php 5.5+


Note that without the use of tags/releases in Github, users receive the following error when installing via `composer require ...`:

> Could not find a version of package convertkit/convertkitapi matching your minimum-stability (stable). Require it with an explicit version constraint allowing its desired stability. 