### PR TITLE
Changed make_request method to public

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -558,7 +558,7 @@ class ConvertKit_API {
      *
      * @return false|mixed
      */
-    private function make_request($endpoint, $method, $args = array()) {
+    public function make_request($endpoint, $method, $args = array()) {
 
         if( !is_string($endpoint) || !is_string($method) || !is_array($args) ) {
             throw new \InvalidArgumentException;


### PR DESCRIPTION
Changed the make_request method in the ConvertKit_API.php file to the public. Since there are lots of API endpoint that are not available as methods in the wrapper, this would allow users to make requests to API endpoints.