### PR TITLE
Change monolog requirement for conflict with Laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php": ">=5.5",
     "guzzlehttp/guzzle": "^6.3",
-    "monolog/monolog": "^1.0"
+    "monolog/monolog": ">=1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php": ">=5.5",
     "guzzlehttp/guzzle": "^6.3",
-    "monolog/monolog": ">=1.0"
+    "monolog/monolog": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0"


### PR DESCRIPTION
First time doing this...updated requirements to allow for Laravel 6+ installs which default to Monolog 2