### PR TITLE
Bump dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-src/logs
-.idea
 .DS_Store
-.phpunit.result.cache
-
+.env
+.env.testing
+composer.lock
+phpstan.neon
+src/logs
+vendor

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,28 @@
 {
   "name": "convertkit/convertkitapi",
-  "description": "ConvertKit API SDK",
-  "keywords": ["convertkit", "api", "forms"],
+  "description": "ConvertKit PHP SDK for the ConvertKit API",
+  "keywords": [
+    "convertkit",
+    "api",
+    "forms"
+  ],
+  "homepage": "https://convertkit.com/",
+  "license": "GPLv3",
+  "authors": [
+    {
+      "name": "ConvertKit and contributors",
+      "homepage": "https://github.com/convertkit/convertkitsdk-php/contributors"
+    }
+  ],
   "require": {
-    "php": ">=5.5",
-    "guzzlehttp/guzzle": "^6.3",
+    "php": ">=7.4",
+    "guzzlehttp/guzzle": "^6.5|^7.0",
     "monolog/monolog": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.0"
+    "phpunit/phpunit": "^5.7 || ^9.0",
+    "squizlabs/php_codesniffer": "^3.3",
+    "phpstan/phpstan": "^1.2",
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require-dev": {
     "phpunit/phpunit": "^5.7 || ^9.0",
     "squizlabs/php_codesniffer": "^3.3",
-    "phpstan/phpstan": "^1.2",
+    "phpstan/phpstan": "^1.2"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Bumps:
- Minimum PHP version to `7.4`
- `guzzlehttp/guzzle` to between `6.5` and `7.0`, depending on PHP version (resolves https://github.com/ConvertKit/ConvertKitSDK-PHP/pull/27, https://github.com/ConvertKit/ConvertKitSDK-PHP/pull/20, https://github.com/ConvertKit/ConvertKitSDK-PHP/issues/26)

For testing:
- Bumps PHPUnit to between `5.7` and `9.0`, depending on PHP version
- Adds codesniffer and static analysis packages, for use in a later testing PR