### PR TITLE
Include User Agent header in API requests

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -20,6 +20,13 @@ use GuzzleHttp\Psr7\Request;
 class ConvertKit_API
 {
     /**
+     * The SDK version.
+     *
+     * @var string
+     */
+    public const VERSION = '1.0.0';
+
+    /**
      * ConvertKit API Key
      *
      * @var string
@@ -95,7 +102,15 @@ class ConvertKit_API
         $this->api_key    = $api_key;
         $this->api_secret = $api_secret;
         $this->debug      = $debug;
-        $this->client     = new Client();
+
+        // Specify a User-Agent for API requests.
+        $this->client = new Client(
+            [
+                'headers' => [
+                    'User-Agent' => 'ConvertKitPHPSDK/' . self::VERSION . ';PHP/' . phpversion(),
+                ],
+            ]
+        );
 
         if ($debug) {
             $this->debug_logger = new Logger('ck-debug');


### PR DESCRIPTION
## Summary

Adds a `User-Agent` header to every API request, allowing us to identify which API requests originate from this PHP SDK.

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)