### PR TITLE
Fix sort order tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -36,6 +36,26 @@ If a test fails, you can inspect the output.
 
 Any errors should be corrected by making applicable code or test changes.
 
+## Run PHP CodeSniffer
+
+[PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) checks that all code meets the [PSR-12 Coding Standards](https://www.php-fig.org/psr/psr-12/).
+
+To run CodeSniffer on tests, enter the following command:
+
+```bash
+vendor/bin/phpcs
+```
+
+Any errors should be corrected by either:
+- making applicable code changes
+- (Experimental) running `vendor/bin/phpcbf` to automatically fix coding standards
+
+Need to change the coding standard rules applied?  Either:
+- ignore a rule in the affected code, by adding `phpcs:ignore {rule}`, where {rule} is the given rule that failed in the above output.
+- edit the [phpcs.tests.xml](phpcs.xml) file.
+
+**Rules can be ignored with caution**, but it's essential that rules relating to coding style and inline code commenting / docblocks remain.
+
 ## Run PHP CodeSniffer for Tests
 
 [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) checks that all test code meets the [PSR-12 Coding Standards](https://www.php-fig.org/psr/psr-12/).

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -438,15 +438,13 @@ class ConvertKit_API
             return false;
         }
 
-        $subscriber_id = $this::check_if_subscriber_in_array($email_address, $subscribers->subscribers);
-
-        if ($subscriber_id) {
-            return $subscriber_id;
+        if ($subscribers->total_subscribers === 0) {
+            $this->create_log('No subscribers');
+            return false;
         }
 
-        $this->create_log('Subscriber not found');
-
-        return false;
+        // Return the subscriber's ID.
+        return $subscribers->subscribers[0]->id;
     }
 
 
@@ -759,28 +757,6 @@ class ConvertKit_API
         }
 
         $this->create_log('Failed to finish request.');
-        return false;
-    }
-
-
-    /**
-     * Looks for subscriber with email in array
-     *
-     * @param string $email_address Email Address.
-     * @param array  $subscribers   Subscribers.
-     *
-     * @return false|integer  false if not found, else subscriber object
-     */
-    private function check_if_subscriber_in_array(string $email_address, array $subscribers)
-    {
-        foreach ($subscribers as $subscriber) {
-            if ($subscriber->email_address === $email_address) {
-                $this->create_log('Subscriber found!');
-                return $subscriber->id;
-            }
-        }
-
-        $this->create_log('Subscriber not found on current page.');
         return false;
     }
 }

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -128,7 +128,7 @@ class ConvertKit_API
      */
     public function get_account()
     {
-        $request = $this->api_version . '/account';
+        $request = 'account';
 
         $options = [
             'api_secret' => $this->api_secret,
@@ -136,7 +136,7 @@ class ConvertKit_API
 
         $this->create_log(sprintf('GET account: %s, %s', $request, json_encode($options)));
 
-        return $this->make_request($request, 'GET', $options);
+        return $this->get($request, $options);
     }
 
 
@@ -147,7 +147,7 @@ class ConvertKit_API
      */
     public function get_sequences()
     {
-        $request = $this->api_version . '/sequences';
+        $request = 'sequences';
 
         $options = [
             'api_key' => $this->api_key,
@@ -155,7 +155,7 @@ class ConvertKit_API
 
         $this->create_log(sprintf('GET sequences: %s, %s', $request, json_encode($options)));
 
-        return $this->make_request($request, 'GET', $options);
+        return $this->get($request, $options);
     }
 
 
@@ -169,7 +169,7 @@ class ConvertKit_API
      */
     public function get_sequence_subscriptions(int $sequence_id, string $sort_order = 'asc')
     {
-        $request = $this->api_version . sprintf('/sequences/%s/subscriptions', $sequence_id);
+        $request = sprintf('sequences/%s/subscriptions', $sequence_id);
 
         $options = [
             'api_secret' => $this->api_secret,
@@ -185,7 +185,7 @@ class ConvertKit_API
             )
         );
 
-        return $this->make_request($request, 'GET', $options);
+        return $this->get($request, $options);
     }
 
 
@@ -199,7 +199,7 @@ class ConvertKit_API
      */
     public function add_subscriber_to_sequence(int $sequence_id, string $email)
     {
-        $request = $this->api_version . sprintf('/courses/%s/subscribe', $sequence_id);
+        $request = sprintf('courses/%s/subscribe', $sequence_id);
 
         $options = [
             'api_key' => $this->api_key,
@@ -216,7 +216,7 @@ class ConvertKit_API
             )
         );
 
-        return $this->make_request($request, 'POST', $options);
+        return $this->post($request, $options);
     }
 
 
@@ -236,13 +236,13 @@ class ConvertKit_API
             throw new \InvalidArgumentException();
         }
 
-        $request = $this->api_version . sprintf('/tags/%s/subscribe', $tag);
+        $request = sprintf('tags/%s/subscribe', $tag);
 
         $options['api_key'] = $this->api_key;
 
         $this->create_log(sprintf('POST add tag: %s, %s, %s', $request, json_encode($options), $tag));
 
-        return $this->make_request($request, 'POST', $options);
+        return $this->post($request, $options);
     }
 
 
@@ -271,11 +271,17 @@ class ConvertKit_API
                 'Accept-Encoding' => 'gzip',
             ];
 
-            $request = sprintf('/%s/%s', $this->api_version, (($resource === 'landing_pages') ? 'forms' : $resource));
+            // Assign the resource to the request variable.
+            $request = $resource;
+
+            // Landing pages are included in the /forms endpoint.
+            if ($resource === 'landing_pages') {
+                $request = 'forms';
+            }
 
             $this->create_log(sprintf('GET request %s, %s', $request, json_encode($options)));
 
-            $resources = $this->make_request($request, 'GET', $options);
+            $resources = $this->get($request, $options);
 
             if (!$resources) {
                 $this->create_log('No resources');
@@ -363,13 +369,13 @@ class ConvertKit_API
             throw new \InvalidArgumentException();
         }
 
-        $request = $this->api_version . sprintf('/forms/%s/subscribe', $form_id);
+        $request = sprintf('forms/%s/subscribe', $form_id);
 
         $options['api_key'] = $this->api_key;
 
         $this->create_log(sprintf('POST form subscribe: %s, %s, %s', $request, json_encode($options), $form_id));
 
-        return $this->make_request($request, 'POST', $options);
+        return $this->post($request, $options);
     }
 
 
@@ -388,13 +394,13 @@ class ConvertKit_API
             throw new \InvalidArgumentException();
         }
 
-        $request = $this->api_version . '/unsubscribe';
+        $request = 'unsubscribe';
 
         $options['api_secret'] = $this->api_secret;
 
         $this->create_log(sprintf('PUT form unsubscribe: %s, %s', $request, json_encode($options)));
 
-        return $this->make_request($request, 'PUT', $options);
+        return $this->put($request, $options);
     }
 
 
@@ -414,7 +420,7 @@ class ConvertKit_API
             throw new \InvalidArgumentException();
         }
 
-        $request = $this->api_version . '/subscribers';
+        $request = 'subscribers';
 
         $options = [
             'api_secret'    => $this->api_secret,
@@ -431,7 +437,7 @@ class ConvertKit_API
             )
         );
 
-        $subscribers = $this->make_request($request, 'GET', $options);
+        $subscribers = $this->get($request, $options);
 
         if (!$subscribers) {
             $this->create_log('No subscribers');
@@ -463,7 +469,7 @@ class ConvertKit_API
             throw new \InvalidArgumentException();
         }
 
-        $request = $this->api_version . sprintf('/subscribers/%s', $subscriber_id);
+        $request = sprintf('subscribers/%s', $subscriber_id);
 
         $options = [
             'api_secret' => $this->api_secret,
@@ -471,7 +477,7 @@ class ConvertKit_API
 
         $this->create_log(sprintf('GET subscriber tags: %s, %s, %s', $request, json_encode($options), $subscriber_id));
 
-        return $this->make_request($request, 'GET', $options);
+        return $this->get($request, $options);
     }
 
 
@@ -490,7 +496,7 @@ class ConvertKit_API
             throw new \InvalidArgumentException();
         }
 
-        $request = $this->api_version . sprintf('/subscribers/%s/tags', $subscriber_id);
+        $request = sprintf('subscribers/%s/tags', $subscriber_id);
 
         $options = [
             'api_key' => $this->api_key,
@@ -498,7 +504,7 @@ class ConvertKit_API
 
         $this->create_log(sprintf('GET subscriber tags: %s, %s, %s', $request, json_encode($options), $subscriber_id));
 
-        return $this->make_request($request, 'GET', $options);
+        return $this->get($request, $options);
     }
 
 
@@ -517,13 +523,13 @@ class ConvertKit_API
             throw new \InvalidArgumentException();
         }
 
-        $request = $this->api_version . '/purchases';
+        $request = 'purchases';
 
         $options['api_secret'] = $this->api_secret;
 
         $this->create_log(sprintf('GET list purchases: %s, %s', $request, json_encode($options)));
 
-        return $this->make_request($request, 'GET', $options);
+        return $this->get($request, $options);
     }
 
 
@@ -542,13 +548,13 @@ class ConvertKit_API
             throw new \InvalidArgumentException();
         }
 
-        $request = $this->api_version . '/purchases';
+        $request = 'purchases';
 
         $options['api_secret'] = $this->api_secret;
 
         $this->create_log(sprintf('POST create purchase: %s, %s', $request, json_encode($options)));
 
-        return $this->make_request($request, 'POST', $options);
+        return $this->post($request, $options);
     }
 
 
@@ -692,6 +698,65 @@ class ConvertKit_API
         return $markup;
     }
 
+    /**
+     * Performs a GET request to the API.
+     *
+     * @param string $endpoint API Endpoint.
+     * @param array  $args     Request arguments.
+     *
+     * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
+     *
+     * @return false|mixed
+     */
+    public function get(string $endpoint, array $args = [])
+    {
+        return $this->make_request($endpoint, 'GET', $args);
+    }
+
+    /**
+     * Performs a POST request to the API.
+     *
+     * @param string $endpoint API Endpoint.
+     * @param array  $args     Request arguments.
+     *
+     * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
+     *
+     * @return false|mixed
+     */
+    public function post(string $endpoint, array $args = [])
+    {
+        return $this->make_request($endpoint, 'POST', $args);
+    }
+
+    /**
+     * Performs a PUT request to the API.
+     *
+     * @param string $endpoint API Endpoint.
+     * @param array  $args     Request arguments.
+     *
+     * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
+     *
+     * @return false|mixed
+     */
+    public function put(string $endpoint, array $args = [])
+    {
+        return $this->make_request($endpoint, 'PUT', $args);
+    }
+
+    /**
+     * Performs a DELETE request to the API.
+     *
+     * @param string $endpoint API Endpoint.
+     * @param array  $args     Request arguments.
+     *
+     * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
+     *
+     * @return false|mixed
+     */
+    public function delete(string $endpoint, array $args = [])
+    {
+        return $this->make_request($endpoint, 'DELETE', $args);
+    }
 
     /**
      * Performs an API request using Guzzle.
@@ -710,7 +775,7 @@ class ConvertKit_API
             throw new \InvalidArgumentException();
         }
 
-        $url = $this->api_url_base . $endpoint;
+        $url = $this->api_url_base . $this->api_version . '/' . $endpoint;
 
         $this->create_log(sprintf('Making request on %s.', $url));
 

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -109,7 +109,10 @@ class ConvertKitAPITest extends TestCase
         $this->assertIsArray($result['subscriptions']);
 
         // Assert sort order is ascending.
-        $this->assertGreaterThanOrEqual($result['subscriptions'][0]->created_at, $result['subscriptions'][1]->created_at);
+        $this->assertGreaterThanOrEqual(
+            $result['subscriptions'][0]->created_at,
+            $result['subscriptions'][1]->created_a
+        );
     }
 
     /**
@@ -134,7 +137,10 @@ class ConvertKitAPITest extends TestCase
         $this->assertIsArray($result['subscriptions']);
 
         // Assert sort order.
-        $this->assertLessThanOrEqual($result['subscriptions'][0]->created_at, $result['subscriptions'][1]->created_at);
+        $this->assertLessThanOrEqual(
+            $result['subscriptions'][0]->created_at,
+            $result['subscriptions'][1]->created_a
+        );
     }
 
     /**

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -111,7 +111,7 @@ class ConvertKitAPITest extends TestCase
         // Assert sort order is ascending.
         $this->assertGreaterThanOrEqual(
             $result['subscriptions'][0]->created_at,
-            $result['subscriptions'][1]->created_a
+            $result['subscriptions'][1]->created_at
         );
     }
 
@@ -139,7 +139,7 @@ class ConvertKitAPITest extends TestCase
         // Assert sort order.
         $this->assertLessThanOrEqual(
             $result['subscriptions'][0]->created_at,
-            $result['subscriptions'][1]->created_a
+            $result['subscriptions'][1]->created_at
         );
     }
 

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -109,7 +109,7 @@ class ConvertKitAPITest extends TestCase
         $this->assertIsArray($result['subscriptions']);
 
         // Assert sort order is ascending.
-        $this->assertGreaterThan($result['subscriptions'][0]->created_at, $result['subscriptions'][1]->created_at);
+        $this->assertGreaterThanOrEqual($result['subscriptions'][0]->created_at, $result['subscriptions'][1]->created_at);
     }
 
     /**
@@ -134,7 +134,7 @@ class ConvertKitAPITest extends TestCase
         $this->assertIsArray($result['subscriptions']);
 
         // Assert sort order.
-        $this->assertLessThan($result['subscriptions'][0]->created_at, $result['subscriptions'][1]->created_at);
+        $this->assertLessThanOrEqual($result['subscriptions'][0]->created_at, $result['subscriptions'][1]->created_at);
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes test failures when asserting the sort order of two items when both items have the same date and time.

Adds section to testing guide covering using CodeSniffer for main code.

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)