### PR TITLE
Replace `check_if_subscriber_in_array()` function

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -438,15 +438,13 @@ class ConvertKit_API
             return false;
         }
 
-        $subscriber_id = $this::check_if_subscriber_in_array($email_address, $subscribers->subscribers);
-
-        if ($subscriber_id) {
-            return $subscriber_id;
+        if ($subscribers->total_subscribers === 0) {
+            $this->create_log('No subscribers');
+            return false;
         }
 
-        $this->create_log('Subscriber not found');
-
-        return false;
+        // Return the subscriber's ID.
+        return $subscribers->subscribers[0]->id;
     }
 
 
@@ -759,28 +757,6 @@ class ConvertKit_API
         }
 
         $this->create_log('Failed to finish request.');
-        return false;
-    }
-
-
-    /**
-     * Looks for subscriber with email in array
-     *
-     * @param string $email_address Email Address.
-     * @param array  $subscribers   Subscribers.
-     *
-     * @return false|integer  false if not found, else subscriber object
-     */
-    private function check_if_subscriber_in_array(string $email_address, array $subscribers)
-    {
-        foreach ($subscribers as $subscriber) {
-            if ($subscriber->email_address === $email_address) {
-                $this->create_log('Subscriber found!');
-                return $subscriber->id;
-            }
-        }
-
-        $this->create_log('Subscriber not found on current page.');
         return false;
     }
 }


### PR DESCRIPTION
## Summary

Replaces the `check_if_subscriber_in_array()` function, as we query the API by `email_address` - so inspecting the response’s `total_subscribers` is sufficient.

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)