### PR TITLE
Added PHPStan for Static Analysis

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -22,6 +22,27 @@ If your work fixes existing functionality, check if a test exists. Either update
 
 Tests are written in PHP using [PHPUnit](https://phpunit.de/), and the existing `tests/ConvertKitAPITest.php` is a good place to start as a guide.
 
+## Run PHPStan
+
+[PHPStan](https://phpstan.org) performs static analysis on the Plugin's PHP code.  This ensures:
+
+- DocBlocks declarations are valid and uniform
+- DocBlocks declarations for WordPress `do_action()` and `apply_filters()` calls are valid
+- Typehinting variables and return types declared in DocBlocks are correctly cast
+- Any unused functions are detected
+- Unnecessary checks / code is highlighted for possible removal
+- Conditions that do not evaluate can be fixed/removed as necessary
+
+In the Plugin's directory, run the following command to run PHPStan:
+
+```bash
+vendor/bin/phpstan --memory-limit=1G
+```
+
+Any errors should be corrected by making applicable code changes.
+
+False positives [can be excluded by configuring](https://phpstan.org/user-guide/ignoring-errors) the `phpstan.neon` file.
+
 ## Run PHPUnit
 
 Once you have written your code and tests, run the tests to make sure there are no errors.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,9 @@
+# Parameters
+parameters:
+    # Paths to scan
+    paths:
+        - src/
+
+    # Should not need to edit anything below here
+    # Rule Level: https://phpstan.org/user-guide/rule-levels
+    level: 6

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,4 +6,9 @@ parameters:
 
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
-    level: 6
+    level: 8
+
+    # Ignore the following errors, as PHPStan either does not have registered symbols for them yet,
+    # or the symbols are inaccurate.
+    ignoreErrors:
+        - '#\$headers of class GuzzleHttp\\Psr7\\Request constructor expects#'

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -1,0 +1,9 @@
+# Parameters
+parameters:
+    # Paths to scan
+    paths:
+        - src/
+
+    # Should not need to edit anything below here
+    # Rule Level: https://phpstan.org/user-guide/rule-levels
+    level: 6

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -6,4 +6,9 @@ parameters:
 
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
-    level: 6
+    level: 8
+
+    # Ignore the following errors, as PHPStan either does not have registered symbols for them yet,
+    # or the symbols are inaccurate.
+    ignoreErrors:
+        - '#\$headers of class GuzzleHttp\\Psr7\\Request constructor expects#'

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -89,6 +89,7 @@ class ConvertKit_API
      */
     protected $client;
 
+
     /**
      * Constructor for ConvertKitAPI instance
      *

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -57,14 +57,14 @@ class ConvertKit_API
     /**
      * API resources
      *
-     * @var array
+     * @var array<int, array<int, \stdClass>>
      */
     protected $resources = [];
 
     /**
      * Additional markup
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $markup = [];
 
@@ -78,7 +78,7 @@ class ConvertKit_API
     /**
      * Debug
      *
-     * @var boolean
+     * @var \Monolog\Logger
      */
     protected $debug_logger;
 
@@ -211,8 +211,8 @@ class ConvertKit_API
     /**
      * Adds a tag to a subscriber
      *
-     * @param integer $tag     Tag ID.
-     * @param array   $options Array of user data.
+     * @param integer               $tag     Tag ID.
+     * @param array<string, mixed>  $options Array of user data.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -220,7 +220,10 @@ class ConvertKit_API
      */
     public function add_tag(int $tag, array $options)
     {
-        if (!is_int($tag) || !is_array($options)) {
+        if (!is_int($tag)) {
+            throw new \InvalidArgumentException();
+        }
+        if (!is_array($options)) {
             throw new \InvalidArgumentException();
         }
 
@@ -244,7 +247,7 @@ class ConvertKit_API
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
-     * @return object API response
+     * @return array<int, \stdClass> API response
      */
     public function get_resources(string $resource)
     {
@@ -365,8 +368,8 @@ class ConvertKit_API
     /**
      * Adds a subscriber to a form.
      *
-     * @param integer $form_id Form ID.
-     * @param array   $options Array of user data (email, name).
+     * @param integer               $form_id Form ID.
+     * @param array<string, string> $options Array of user data (email, name).
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -374,7 +377,10 @@ class ConvertKit_API
      */
     public function form_subscribe(int $form_id, array $options)
     {
-        if (!is_int($form_id) || !is_array($options)) {
+        if (!is_int($form_id)) {
+            throw new \InvalidArgumentException();
+        }
+        if (!is_array($options)) {
             throw new \InvalidArgumentException();
         }
 
@@ -391,7 +397,7 @@ class ConvertKit_API
     /**
      * Remove subscription from a form
      *
-     * @param array $options Array of user data (email).
+     * @param array<string, string> $options Array of user data (email).
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -422,7 +428,10 @@ class ConvertKit_API
      */
     public function get_subscriber_id(string $email_address)
     {
-        if (!is_string($email_address) || !filter_var($email_address, FILTER_VALIDATE_EMAIL)) {
+        if (!is_string($email_address)) {
+            throw new \InvalidArgumentException();
+        }
+        if (!filter_var($email_address, FILTER_VALIDATE_EMAIL)) {
             throw new \InvalidArgumentException();
         }
 
@@ -481,7 +490,7 @@ class ConvertKit_API
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
-     * @return false|array
+     * @return false|array<int,\stdClass>
      */
     public function get_subscriber_tags(int $subscriber_id)
     {
@@ -501,7 +510,7 @@ class ConvertKit_API
     /**
      * List purchases.
      *
-     * @param array $options Request options.
+     * @param array<string, string> $options Request options.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -523,7 +532,7 @@ class ConvertKit_API
     /**
      * Creates a purchase.
      *
-     * @param array $options Purchase data.
+     * @param array<string, string> $options Purchase data.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -557,7 +566,10 @@ class ConvertKit_API
      */
     public function get_resource(string $url)
     {
-        if (!is_string($url) || !filter_var($url, FILTER_VALIDATE_URL)) {
+        if (!is_string($url)) {
+            throw new \InvalidArgumentException();
+        }
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
             throw new \InvalidArgumentException();
         }
 
@@ -625,7 +637,7 @@ class ConvertKit_API
      * Converts any relative URls to absolute, fully qualified HTTP(s) URLs for the given
      * DOM Elements.
      *
-     * @param \DOMNodeList $elements  Elements.
+     * @param \DOMNodeList<\DOMElement> $elements  Elements.
      * @param string       $attribute HTML Attribute.
      * @param string       $url       Absolute URL to prepend to relative URLs.
      *
@@ -685,8 +697,8 @@ class ConvertKit_API
     /**
      * Performs a GET request to the API.
      *
-     * @param string $endpoint API Endpoint.
-     * @param array  $args     Request arguments.
+     * @param string                $endpoint API Endpoint.
+     * @param array<string,string>  $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -704,8 +716,8 @@ class ConvertKit_API
     /**
      * Performs a POST request to the API.
      *
-     * @param string $endpoint API Endpoint.
-     * @param array  $args     Request arguments.
+     * @param string                $endpoint API Endpoint.
+     * @param array<string,string>  $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -723,8 +735,8 @@ class ConvertKit_API
     /**
      * Performs a PUT request to the API.
      *
-     * @param string $endpoint API Endpoint.
-     * @param array  $args     Request arguments.
+     * @param string                $endpoint API Endpoint.
+     * @param array<string,string>  $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -742,8 +754,8 @@ class ConvertKit_API
     /**
      * Performs a DELETE request to the API.
      *
-     * @param string $endpoint API Endpoint.
-     * @param array  $args     Request arguments.
+     * @param string                $endpoint API Endpoint.
+     * @param array<string,string>  $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -761,9 +773,9 @@ class ConvertKit_API
     /**
      * Performs an API request using Guzzle.
      *
-     * @param string $endpoint API Endpoint.
-     * @param string $method   Request method (POST, GET, PUT, PATCH, DELETE).
-     * @param array  $args     Request arguments.
+     * @param string                $endpoint API Endpoint.
+     * @param string                $method   Request method (POST, GET, PUT, PATCH, DELETE).
+     * @param array<string,string>  $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -771,7 +783,13 @@ class ConvertKit_API
      */
     public function make_request(string $endpoint, string $method, array $args = [])
     {
-        if (!is_string($endpoint) || !is_string($method) || !is_array($args)) {
+        if (!is_string($endpoint)) {
+            throw new \InvalidArgumentException();
+        }
+        if (!is_string($method)) {
+            throw new \InvalidArgumentException();
+        }
+        if (!is_array($args)) {
             throw new \InvalidArgumentException();
         }
 

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -211,8 +211,8 @@ class ConvertKit_API
     /**
      * Adds a tag to a subscriber
      *
-     * @param integer               $tag     Tag ID.
-     * @param array<string, mixed>  $options Array of user data.
+     * @param integer              $tag     Tag ID.
+     * @param array<string, mixed> $options Array of user data.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -638,14 +638,14 @@ class ConvertKit_API
      * DOM Elements.
      *
      * @param \DOMNodeList<\DOMElement> $elements  Elements.
-     * @param string       $attribute HTML Attribute.
-     * @param string       $url       Absolute URL to prepend to relative URLs.
+     * @param string                    $attribute HTML Attribute.
+     * @param string                    $url       Absolute URL to prepend to relative URLs.
      *
      * @since 1.0.0
      *
      * @return void
      */
-    private function convert_relative_to_absolute_urls(\DOMNodeList $elements, string $attribute, string $url)
+    private function convert_relative_to_absolute_urls(\DOMNodeList $elements, string $attribute, string $url) // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint, Generic.Files.LineLength.TooLong
     {
         // Anchor hrefs.
         foreach ($elements as $element) {
@@ -697,8 +697,8 @@ class ConvertKit_API
     /**
      * Performs a GET request to the API.
      *
-     * @param string                $endpoint API Endpoint.
-     * @param array<string,string>  $args     Request arguments.
+     * @param string               $endpoint API Endpoint.
+     * @param array<string,string> $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -716,8 +716,8 @@ class ConvertKit_API
     /**
      * Performs a POST request to the API.
      *
-     * @param string                $endpoint API Endpoint.
-     * @param array<string,string>  $args     Request arguments.
+     * @param string               $endpoint API Endpoint.
+     * @param array<string,string> $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -735,8 +735,8 @@ class ConvertKit_API
     /**
      * Performs a PUT request to the API.
      *
-     * @param string                $endpoint API Endpoint.
-     * @param array<string,string>  $args     Request arguments.
+     * @param string               $endpoint API Endpoint.
+     * @param array<string,string> $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -754,8 +754,8 @@ class ConvertKit_API
     /**
      * Performs a DELETE request to the API.
      *
-     * @param string                $endpoint API Endpoint.
-     * @param array<string,string>  $args     Request arguments.
+     * @param string               $endpoint API Endpoint.
+     * @param array<string,string> $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -773,9 +773,9 @@ class ConvertKit_API
     /**
      * Performs an API request using Guzzle.
      *
-     * @param string                $endpoint API Endpoint.
-     * @param string                $method   Request method (POST, GET, PUT, PATCH, DELETE).
-     * @param array<string,string>  $args     Request arguments.
+     * @param string               $endpoint API Endpoint.
+     * @param string               $method   Request method (POST, GET, PUT, PATCH, DELETE).
+     * @param array<string,string> $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *


### PR DESCRIPTION
## Summary

Adds PHPStan for static analysis, covering:
- Correct variable declarations
- More accurate typehints in docblocks when specifying or returning arrays
- Moving `InvalidArgumentException` checks onto individual `if` blocks to prevent false positive reports in PHPStan
- Passing valid variable types to functions such as `preg_replace`
- Improved type checking on return values such as `json_encode`

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)