### PR TITLE
Add `get_forms()` and `get_landing_pages()` API functions

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -151,6 +151,30 @@ class ConvertKit_API
     }
 
     /**
+     * Gets all forms.
+     *
+     * @since 1.0.0
+     *
+     * @return false|mixed
+     */
+    public function get_forms()
+    {
+        return $this->get_resources('forms');
+    }
+
+    /**
+     * Gets all landing pages.
+     *
+     * @since 1.0.0
+     *
+     * @return false|mixed
+     */
+    public function get_landing_pages()
+    {
+        return $this->get_resources('landing_pages');
+    }
+
+    /**
      * Gets all sequences
      *
      * @return false|mixed
@@ -266,9 +290,7 @@ class ConvertKit_API
         $resources = $this->get(
             $request,
             [
-                'api_key'         => $this->api_key,
-                'timeout'         => 10,
-                'Accept-Encoding' => 'gzip',
+                'api_key' => $this->api_key,
             ]
         );
 
@@ -291,9 +313,15 @@ class ConvertKit_API
                     return [];
                 }
 
-                // Exclude archived forms.
+                // Build array of forms.
                 foreach ($resources->forms as $form) {
+                    // Exclude archived forms.
                     if (isset($form->archived) && $form->archived) {
+                        continue;
+                    }
+
+                    // Exclude hosted forms.
+                    if ($form->type === 'hosted') {
                         continue;
                     }
 
@@ -309,12 +337,13 @@ class ConvertKit_API
                     return [];
                 }
 
-                // Exclude forms and archived forms/landing pages.
                 foreach ($resources->forms as $form) {
+                    // Exclude archived landing pages.
                     if (isset($form->archived) && $form->archived) {
                         continue;
                     }
 
+                    // Exclude non-hosted (i.e. forms).
                     if ($form->type !== 'hosted') {
                         continue;
                     }

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -66,6 +66,55 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that get_forms() returns the expected data.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testGetForms()
+    {
+        $result = $this->api->get_forms();
+        $this->assertIsArray($result);
+
+        // Convert to array to check for keys, as assertObjectHasAttribute() will be deprecated in PHPUnit 10.
+        $form = get_object_vars($result[0]);
+        $this->assertArrayHasKey('id', $form);
+        $this->assertArrayHasKey('name', $form);
+        $this->assertArrayHasKey('created_at', $form);
+        $this->assertArrayHasKey('type', $form);
+        $this->assertArrayHasKey('format', $form);
+        $this->assertArrayHasKey('embed_js', $form);
+        $this->assertArrayHasKey('embed_url', $form);
+        $this->assertArrayHasKey('archived', $form);
+    }
+
+    /**
+     * Test that get_landing_pages() returns the expected data.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testGetLandingPages()
+    {
+        $result = $this->api->get_landing_pages();
+        $this->assertIsArray($result);
+
+        // Convert to array to check for keys, as assertObjectHasAttribute() will be deprecated in PHPUnit 10.
+        $landingPage = get_object_vars($result[0]);
+        $this->assertArrayHasKey('id', $landingPage);
+        $this->assertArrayHasKey('name', $landingPage);
+        $this->assertArrayHasKey('created_at', $landingPage);
+        $this->assertArrayHasKey('type', $landingPage);
+        $this->assertEquals('hosted', $landingPage['type']);
+        $this->assertArrayHasKey('format', $landingPage);
+        $this->assertArrayHasKey('embed_js', $landingPage);
+        $this->assertArrayHasKey('embed_url', $landingPage);
+        $this->assertArrayHasKey('archived', $landingPage);
+    }
+
+    /**
      * Test that get_sequences() returns the expected data.
      *
      * @since   1.0.0


### PR DESCRIPTION
## Summary

Adds `get_forms()` and `get_landing_pages()` API functions, as a convenience vs. having to call `get_resources('forms')` or `get_resources('landing_pages')`.

Removes unnecessary timeout and encoding headers on requests for resources.

When fetching landing pages, exclude forms from the resultset.

## Testing

- `testGetForms`: Tests that fetching forms works with expected response data.
- `testGetLandingPages`: Tests that fetching landing pages works with expected response data.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)