### PR TITLE
Update `add_subscriber_to_sequence()` to support name, custom fields and tags

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -152,7 +152,7 @@ class ConvertKit_API
 
     /**
      * Gets all sequences
-     * 
+     *
      * @see https://developers.convertkit.com/#list-sequences
      *
      * @return false|mixed
@@ -175,13 +175,18 @@ class ConvertKit_API
      * @param string                $first_name  First Name.
      * @param array<string, string> $fields      Custom Fields.
      * @param array<string, int>    $tag_ids     Tag ID(s) to subscribe to.
-     * 
+     *
      * @see https://developers.convertkit.com/#add-subscriber-to-a-sequence
      *
      * @return false|mixed
      */
-    public function add_subscriber_to_sequence(int $sequence_id, string $email, string $first_name = '', array $fields = [], array $tag_ids = [])
-    {
+    public function add_subscriber_to_sequence(
+        int $sequence_id,
+        string $email,
+        string $first_name = '',
+        array $fields = [],
+        array $tag_ids = []
+    ) {
         // Build parameters.
         $options = [
             'api_key' => $this->api_key,
@@ -194,7 +199,7 @@ class ConvertKit_API
         if (!empty($fields)) {
             $options['fields'] = $fields;
         }
-        if (!empty($tags)) {
+        if (!empty($tag_ids)) {
             $options['tags'] = $tag_ids;
         }
 
@@ -212,7 +217,7 @@ class ConvertKit_API
      * @param string  $sort_order       Sort Order (asc|desc).
      * @param string  $subscriber_state Subscriber State (active,cancelled).
      * @param integer $page             Page.
-     * 
+     *
      * @see https://developers.convertkit.com/#list-subscriptions-to-a-sequence
      *
      * @return false|mixed
@@ -222,14 +227,14 @@ class ConvertKit_API
         string $sort_order = 'asc',
         string $subscriber_state = 'active',
         int $page = 1
-    ){
+    ) {
         return $this->get(
             sprintf('sequences/%s/subscriptions', $sequence_id),
             [
-                'api_secret'        => $this->api_secret,
-                'sort_order'        => $sort_order,
-                'subscriber_state'  => $subscriber_state,
-                'page'              => $page,
+                'api_secret'       => $this->api_secret,
+                'sort_order'       => $sort_order,
+                'subscriber_state' => $subscriber_state,
+                'page'             => $page,
             ]
         );
     }
@@ -720,8 +725,8 @@ class ConvertKit_API
     /**
      * Performs a GET request to the API.
      *
-     * @param string                    $endpoint API Endpoint.
-     * @param array<string, int|string> $args     Request arguments.
+     * @param string                                                     $endpoint API Endpoint.
+     * @param array<string, int|string|array<string, int|string>|string> $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -739,8 +744,8 @@ class ConvertKit_API
     /**
      * Performs a POST request to the API.
      *
-     * @param string                    $endpoint API Endpoint.
-     * @param array<string, int|string> $args     Request arguments.
+     * @param string                                                     $endpoint API Endpoint.
+     * @param array<string, int|string|array<string, int|string>|string> $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -758,8 +763,8 @@ class ConvertKit_API
     /**
      * Performs a PUT request to the API.
      *
-     * @param string                    $endpoint API Endpoint.
-     * @param array<string, int|string> $args     Request arguments.
+     * @param string                                                     $endpoint API Endpoint.
+     * @param array<string, int|string|array<string, int|string>|string> $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -777,8 +782,8 @@ class ConvertKit_API
     /**
      * Performs a DELETE request to the API.
      *
-     * @param string                    $endpoint API Endpoint.
-     * @param array<string, int|string> $args     Request arguments.
+     * @param string                                                     $endpoint API Endpoint.
+     * @param array<string, int|string|array<string, int|string>|string> $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -796,9 +801,9 @@ class ConvertKit_API
     /**
      * Performs an API request using Guzzle.
      *
-     * @param string                    $endpoint API Endpoint.
-     * @param string                    $method   Request method (POST, GET, PUT, PATCH, DELETE).
-     * @param array<string, int|string> $args     Request arguments.
+     * @param string                                                     $endpoint API Endpoint.
+     * @param string                                                     $method   Request method.
+     * @param array<string, int|string|array<string, int|string>|string> $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      * @throws \Exception If JSON encoding arguments failed.

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -152,6 +152,8 @@ class ConvertKit_API
 
     /**
      * Gets all sequences
+     * 
+     * @see https://developers.convertkit.com/#list-sequences
      *
      * @return false|mixed
      */
@@ -166,39 +168,68 @@ class ConvertKit_API
     }
 
     /**
-     * Gets subscribers to a sequence
+     * Adds a subscriber to a sequence by email address
      *
-     * @param integer $sequence_id Sequence ID.
-     * @param string  $sort_order  Sort Order (asc|desc).
+     * @param integer               $sequence_id Sequence ID.
+     * @param string                $email       Email Address.
+     * @param string                $first_name  First Name.
+     * @param array<string, string> $fields      Custom Fields.
+     * @param array<string, int>    $tag_ids     Tag ID(s) to subscribe to.
+     * 
+     * @see https://developers.convertkit.com/#add-subscriber-to-a-sequence
      *
      * @return false|mixed
      */
-    public function get_sequence_subscriptions(int $sequence_id, string $sort_order = 'asc')
+    public function add_subscriber_to_sequence(int $sequence_id, string $email, string $first_name = '', array $fields = [], array $tag_ids = [])
     {
-        return $this->get(
-            sprintf('sequences/%s/subscriptions', $sequence_id),
-            [
-                'api_secret' => $this->api_secret,
-                'sort_order' => $sort_order,
-            ]
+        // Build parameters.
+        $options = [
+            'api_key' => $this->api_key,
+            'email'   => $email,
+        ];
+
+        if (!empty($first_name)) {
+            $options['first_name'] = $first_name;
+        }
+        if (!empty($fields)) {
+            $options['fields'] = $fields;
+        }
+        if (!empty($tags)) {
+            $options['tags'] = $tag_ids;
+        }
+
+        // Send request.
+        return $this->post(
+            sprintf('sequences/%s/subscribe', $sequence_id),
+            $options
         );
     }
 
     /**
-     * Adds a subscriber to a sequence by email address
+     * Gets subscribers to a sequence
      *
-     * @param integer $sequence_id Sequence ID.
-     * @param string  $email       Email Address.
+     * @param integer $sequence_id      Sequence ID.
+     * @param string  $sort_order       Sort Order (asc|desc).
+     * @param string  $subscriber_state Subscriber State (active,cancelled).
+     * @param integer $page             Page.
+     * 
+     * @see https://developers.convertkit.com/#list-subscriptions-to-a-sequence
      *
      * @return false|mixed
      */
-    public function add_subscriber_to_sequence(int $sequence_id, string $email)
-    {
-        return $this->post(
-            sprintf('courses/%s/subscribe', $sequence_id),
+    public function get_sequence_subscriptions(
+        int $sequence_id,
+        string $sort_order = 'asc',
+        string $subscriber_state = 'active',
+        int $page = 1
+    ){
+        return $this->get(
+            sprintf('sequences/%s/subscriptions', $sequence_id),
             [
-                'api_key' => $this->api_key,
-                'email'   => $email,
+                'api_secret'        => $this->api_secret,
+                'sort_order'        => $sort_order,
+                'subscriber_state'  => $subscriber_state,
+                'page'              => $page,
             ]
         );
     }

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -87,6 +87,131 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that add_subscriber_to_sequence() returns the expected data.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testAddSubscriberToSequence()
+    {
+        $result = $this->api->add_subscriber_to_sequence(
+            $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+            $this->generateEmailAddress()
+        );
+        $this->assertInstanceOf('stdClass', $result);
+        $this->assertArrayHasKey('subscription', get_object_vars($result));
+    }
+
+    /**
+     * Test that add_subscriber_to_sequence() throws a ClientException when an invalid
+     * sequence is specified.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testAddSubscriberToSequenceWithInvalidSequenceID()
+    {
+        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $result = $this->api->add_subscriber_to_sequence(12345, $this->generateEmailAddress());
+    }
+
+    /**
+     * Test that add_subscriber_to_sequence() throws a ClientException when an invalid
+     * email address is specified.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testAddSubscriberToSequenceWithInvalidEmailAddress()
+    {
+        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $result = $this->api->add_subscriber_to_sequence($_ENV['CONVERTKIT_API_SEQUENCE_ID'], 'not-an-email-address');
+    }
+
+    /**
+     * Test that add_subscriber_to_sequence() returns the expected data
+     * when a first_name parameter is included.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testAddSubscriberToSequenceWithFirstName()
+    {
+        $emailAddress = $this->generateEmailAddress();
+        $firstName = 'First Name';
+        $result = $this->api->add_subscriber_to_sequence($_ENV['CONVERTKIT_API_SEQUENCE_ID'], $emailAddress, $firstName);
+
+        $this->assertInstanceOf('stdClass', $result);
+        $this->assertArrayHasKey('subscription', get_object_vars($result));
+
+        // Fetch subscriber from API to confirm the first name was saved.
+        $subscriber = $this->api->get_subscriber($result->subscription->subscriber->id);
+        $this->assertEquals($subscriber->subscriber->email_address, $emailAddress);
+        $this->assertEquals($subscriber->subscriber->first_name, $firstName);
+    }
+
+    /**
+     * Test that add_subscriber_to_sequence() returns the expected data
+     * when custom field data is included.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testAddSubscriberToSequenceWithCustomFields()
+    {
+        $result = $this->api->add_subscriber_to_sequence(
+            $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+            $this->generateEmailAddress(),
+            'First Name',
+            [
+                'last_name' => 'Last Name',
+            ]
+        );
+
+        // Check subscription object returned.
+        $this->assertInstanceOf('stdClass', $result);
+        $this->assertArrayHasKey('subscription', get_object_vars($result));
+
+        // Fetch subscriber from API to confirm the custom fields were saved.
+        $subscriber = $this->api->get_subscriber($result->subscription->subscriber->id);
+        $this->assertEquals($subscriber->subscriber->fields->last_name, 'Last Name');
+    }
+
+    /**
+     * Test that add_subscriber_to_sequence() returns the expected data
+     * when custom field data is included.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testAddSubscriberToSequenceWithTagID()
+    {
+        $result = $this->api->add_subscriber_to_sequence(
+            $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+            $this->generateEmailAddress(),
+            'First Name',
+            [],
+            [
+                (int) $_ENV['CONVERTKIT_API_TAG_ID']
+            ]
+        );
+
+        // Check subscription object returned.
+        $this->assertInstanceOf('stdClass', $result);
+        $this->assertArrayHasKey('subscription', get_object_vars($result));
+
+        // Fetch subscriber tags from API to confirm the tag saved.
+        $subscriberTags = $this->api->get_subscriber_tags($result->subscription->subscriber->id);
+        // @TODO.
+    }
+
+    /**
      * Test that get_sequence_subscriptions() returns the expected data.
      *
      * @since   1.0.0
@@ -145,20 +270,6 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that get_sequence_subscriptions() throws a ClientException when an invalid
-     * sequence ID is specified.
-     *
-     * @since   1.0.0
-     *
-     * @return void
-     */
-    public function testGetSequenceSubscriptionsWithInvalidSequenceID()
-    {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
-        $result = $this->api->get_sequence_subscriptions(12345);
-    }
-
-    /**
-     * Test that get_sequence_subscriptions() throws a ClientException when an invalid
      * sort order is specified.
      *
      * @since   1.0.0
@@ -172,48 +283,17 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
-     * Test that add_subscriber_to_sequence() returns the expected data.
+     * Test that get_sequence_subscriptions() throws a ClientException when an invalid
+     * sequence ID is specified.
      *
      * @since   1.0.0
      *
      * @return void
      */
-    public function testAddSubscriberToSequence()
-    {
-        $result = $this->api->add_subscriber_to_sequence(
-            $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-            $this->generateEmailAddress()
-        );
-        $this->assertInstanceOf('stdClass', $result);
-        $this->assertArrayHasKey('subscription', get_object_vars($result));
-    }
-
-    /**
-     * Test that add_subscriber_to_sequence() throws a ClientException when an invalid
-     * sequence is specified.
-     *
-     * @since   1.0.0
-     *
-     * @return void
-     */
-    public function testAddSubscriberToSequenceWithInvalidSequenceID()
+    public function testGetSequenceSubscriptionsWithInvalidSequenceID()
     {
         $this->expectException(GuzzleHttp\Exception\ClientException::class);
-        $result = $this->api->add_subscriber_to_sequence(12345, $this->generateEmailAddress());
-    }
-
-    /**
-     * Test that add_subscriber_to_sequence() throws a ClientException when an invalid
-     * email address is specified.
-     *
-     * @since   1.0.0
-     *
-     * @return void
-     */
-    public function testAddSubscriberToSequenceWithInvalidEmailAddress()
-    {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
-        $result = $this->api->add_subscriber_to_sequence($_ENV['CONVERTKIT_API_SEQUENCE_ID'], 'not-an-email-address');
+        $result = $this->api->get_sequence_subscriptions(12345);
     }
 
     /**

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -143,7 +143,11 @@ class ConvertKitAPITest extends TestCase
     {
         $emailAddress = $this->generateEmailAddress();
         $firstName = 'First Name';
-        $result = $this->api->add_subscriber_to_sequence($_ENV['CONVERTKIT_API_SEQUENCE_ID'], $emailAddress, $firstName);
+        $result = $this->api->add_subscriber_to_sequence(
+            $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+            $emailAddress,
+            $firstName
+        );
 
         $this->assertInstanceOf('stdClass', $result);
         $this->assertArrayHasKey('subscription', get_object_vars($result));
@@ -208,7 +212,7 @@ class ConvertKitAPITest extends TestCase
 
         // Fetch subscriber tags from API to confirm the tag saved.
         $subscriberTags = $this->api->get_subscriber_tags($result->subscription->subscriber->id);
-        // @TODO.
+        $this->assertEquals($subscriberTags->tags[0]->id, $_ENV['CONVERTKIT_API_TAG_ID']);
     }
 
     /**


### PR DESCRIPTION
## Summary

Updates the `add_subscriber_to_sequence()` API function, to include support for first name, custom fields and tags, per https://developers.convertkit.com/#add-subscriber-to-a-sequence.

Adds tests to improve test coverage of new function arguments.

## Testing

- `testAddSubscriberToSequenceWithFirstName`: Test that adding a subscriber to a sequence with a first name specified works.
- `testAddSubscriberToSequenceWithCustomFields`: Test that adding a subscriber to a sequence with a custom field works.
- `testAddSubscriberToSequenceWithTagID`: Test that adding a subscriber to a sequence with a tag ID works.
- `testGetSequenceSubscriptionsWithDescSortOrder`: Test that fetching a subscriber's sequences in descending order works.
- `testGetSequenceSubscriptionsWithInvalidSortOrder`: Test that a `ClientException` is thrown when an fetching a subscriber's sequences with an invalid sort order.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)