### PR TITLE
Add Custom Field API functions

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -590,6 +590,103 @@ class ConvertKit_API
     }
 
     /**
+     * List custom fields.
+     *
+     * @since 1.0.0
+     *
+     * @return false|object
+     */
+    public function get_custom_fields()
+    {
+        return $this->get(
+            'custom_fields',
+            [
+                'api_key' => $this->api_key,
+            ]
+        );
+    }
+
+    /**
+     * Creates a custom field.
+     *
+     * @param string $label Custom Field label.
+     *
+     * @since 1.0.0
+     *
+     * @return false|object
+     */
+    public function create_custom_field(string $label)
+    {
+        return $this->post(
+            'custom_fields',
+            [
+                'api_secret' => $this->api_secret,
+                'label'      => [$label],
+            ]
+        );
+    }
+
+    /**
+     * Creates multiple custom fields.
+     *
+     * @param array<string> $labels Custom Fields labels.
+     *
+     * @since 1.0.0
+     *
+     * @return false|object
+     */
+    public function create_custom_fields(array $labels)
+    {
+        return $this->post(
+            'custom_fields',
+            [
+                'api_secret' => $this->api_secret,
+                'label'      => $labels,
+            ]
+        );
+    }
+
+    /**
+     * Updates an existing custom field.
+     *
+     * @param integer $id    Custom Field ID.
+     * @param string  $label Updated Custom Field label.
+     *
+     * @since 1.0.0
+     *
+     * @return false|object
+     */
+    public function update_custom_field(int $id, string $label)
+    {
+        return $this->put(
+            sprintf('custom_fields/%s', $id),
+            [
+                'api_secret' => $this->api_secret,
+                'label'      => $label,
+            ]
+        );
+    }
+
+    /**
+     * Deletes an existing custom field.
+     *
+     * @param integer $id Custom Field ID.
+     *
+     * @since 1.0.0
+     *
+     * @return false|object
+     */
+    public function delete_custom_field(int $id)
+    {
+        return $this->delete(
+            sprintf('custom_fields/%s', $id),
+            [
+                'api_secret' => $this->api_secret,
+            ]
+        );
+    }
+
+    /**
      * List purchases.
      *
      * @param array<string, string> $options Request options.
@@ -802,8 +899,8 @@ class ConvertKit_API
     /**
      * Performs a POST request to the API.
      *
-     * @param string                                                     $endpoint API Endpoint.
-     * @param array<string, int|string|array<string, int|string>|string> $args     Request arguments.
+     * @param string                                                         $endpoint API Endpoint.
+     * @param array<string, int|string|array<int|string, int|string>|string> $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -859,9 +956,9 @@ class ConvertKit_API
     /**
      * Performs an API request using Guzzle.
      *
-     * @param string                                                     $endpoint API Endpoint.
-     * @param string                                                     $method   Request method.
-     * @param array<string, int|string|array<string, int|string>|string> $args     Request arguments.
+     * @param string                                                         $endpoint API Endpoint.
+     * @param string                                                         $method   Request method.
+     * @param array<string, int|string|array<int|string, int|string>|string> $args     Request arguments.
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      * @throws \Exception If JSON encoding arguments failed.

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -594,6 +594,8 @@ class ConvertKit_API
      *
      * @since 1.0.0
      *
+     * @see https://developers.convertkit.com/#list-fields
+     *
      * @return false|object
      */
     public function get_custom_fields()
@@ -612,6 +614,8 @@ class ConvertKit_API
      * @param string $label Custom Field label.
      *
      * @since 1.0.0
+     *
+     * @see https://developers.convertkit.com/#create-field
      *
      * @return false|object
      */
@@ -632,6 +636,8 @@ class ConvertKit_API
      * @param array<string> $labels Custom Fields labels.
      *
      * @since 1.0.0
+     *
+     * @see https://developers.convertkit.com/#create-field
      *
      * @return false|object
      */
@@ -654,6 +660,8 @@ class ConvertKit_API
      *
      * @since 1.0.0
      *
+     * @see https://developers.convertkit.com/#update-field
+     *
      * @return false|object
      */
     public function update_custom_field(int $id, string $label)
@@ -673,6 +681,8 @@ class ConvertKit_API
      * @param integer $id Custom Field ID.
      *
      * @since 1.0.0
+     *
+     * @see https://developers.convertkit.com/#destroy-field
      *
      * @return false|object
      */

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -694,6 +694,179 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that get_custom_fields() returns the expected data.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testGetCustomFields()
+    {
+        $result = $this->api->get_custom_fields();
+        $this->assertInstanceOf('stdClass', $result);
+        $this->assertArrayHasKey('custom_fields', get_object_vars($result));
+
+        // Inspect first custom field.
+        $customField = get_object_vars($result->custom_fields[0]);
+        $this->assertArrayHasKey('id', $customField);
+        $this->assertArrayHasKey('name', $customField);
+        $this->assertArrayHasKey('key', $customField);
+        $this->assertArrayHasKey('label', $customField);
+    }
+
+    /**
+     * Test that create_custom_field() works.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testCreateCustomField()
+    {
+        $label = 'Custom Field ' . mt_rand();
+        $result = $this->api->create_custom_field($label);
+
+        $result = get_object_vars($result);
+        $this->assertArrayHasKey('id', $result);
+        $this->assertArrayHasKey('name', $result);
+        $this->assertArrayHasKey('key', $result);
+        $this->assertArrayHasKey('label', $result);
+        $this->assertEquals($result['label'], $label);
+
+        // Delete custom field.
+        $this->api->delete_custom_field($result['id']);
+    }
+
+    /**
+     * Test that create_custom_field() throws a ClientException when a blank
+     * label is specified.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testCreateCustomFieldWithBlankLabel()
+    {
+        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->api->create_custom_field('');
+    }
+
+    /**
+     * Test that create_custom_fields() works.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testCreateCustomFields()
+    {
+        $labels = [
+            'Custom Field ' . mt_rand(),
+            'Custom Field ' . mt_rand(),
+        ];
+        $result = $this->api->create_custom_fields($labels);
+
+        // Confirm result is an array comprising of each custom field that was created.
+        $this->assertIsArray($result);
+        foreach ($result as $index => $customField) {
+            // Confirm individual custom field.
+            $customField = get_object_vars($customField);
+            $this->assertArrayHasKey('id', $customField);
+            $this->assertArrayHasKey('name', $customField);
+            $this->assertArrayHasKey('key', $customField);
+            $this->assertArrayHasKey('label', $customField);
+
+            // Confirm label is correct.
+            $this->assertEquals($labels[$index], $customField['label']);
+
+            // Delete custom field as tests passed.
+            $this->api->delete_custom_field($customField['id']);
+        }
+    }
+
+    /**
+     * Test that update_custom_field() works.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testUpdateCustomField()
+    {
+        // Create custom field.
+        $label = 'Custom Field ' . mt_rand();
+        $result = $this->api->create_custom_field($label);
+        $id = $result->id;
+
+        // Change label.
+        $newLabel = 'Custom Field ' . mt_rand();
+        $this->api->update_custom_field($id, $newLabel);
+
+        // Confirm label changed.
+        $customFields = $this->api->get_custom_fields();
+        foreach ($customFields->custom_fields as $customField) {
+            if ($customField->id === $id) {
+                $this->assertEquals($customField->label, $newLabel);
+            }
+        }
+
+        // Delete custom field as tests passed.
+        $this->api->delete_custom_field($id);
+    }
+
+    /**
+     * Test that update_custom_field() throws a ClientException when an
+     * invalid custom field ID is specified.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testUpdateCustomFieldWithInvalidID()
+    {
+        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->api->update_custom_field(12345, 'Something');
+    }
+
+    /**
+     * Test that delete_custom_field() works.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testDeleteCustomField()
+    {
+        // Create custom field.
+        $label = 'Custom Field ' . mt_rand();
+        $result = $this->api->create_custom_field($label);
+        $id = $result->id;
+
+        // Delete custom field as tests passed.
+        $this->api->delete_custom_field($id);
+
+        // Confirm custom field no longer exists.
+        $customFields = $this->api->get_custom_fields();
+        foreach ($customFields->custom_fields as $customField) {
+            $this->assertNotEquals($customField->id, $id);
+        }
+    }
+
+    /**
+     * Test that delete_custom_field() throws a ClientException when an
+     * invalid custom field ID is specified.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testDeleteCustomFieldWithInvalidID()
+    {
+        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->api->delete_custom_field(12345);
+    }
+
+    /**
      * Test that list_purchases() returns the expected data.
      *
      * @since   1.0.0


### PR DESCRIPTION
## Summary

Adds the following API functions to provide API coverage for [Custom Fields](https://developers.convertkit.com/#custom-fields)
- `get_custom_fields()`
- `add_custom_field()`
- `add_custom_fields()`
- `update_custom_field()`
- `delete_custom_field()`

## Testing

- Tests for above functions included.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)