### PR TITLE
Add `get_purchase()` function

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -593,7 +593,7 @@ class ConvertKit_API
      * List purchases.
      *
      * @param array<string, string> $options Request options.
-     * 
+     *
      * @see https://developers.convertkit.com/#list-purchases
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
@@ -616,7 +616,7 @@ class ConvertKit_API
      * Retuns a specific purchase.
      *
      * @param integer $purchase_id Purchase ID.
-     * 
+     *
      * @see https://developers.convertkit.com/#retrieve-a-specific-purchase
      *
      * @return false|object
@@ -635,7 +635,7 @@ class ConvertKit_API
      * Creates a purchase.
      *
      * @param array<string, string> $options Purchase data.
-     * 
+     *
      * @see https://developers.convertkit.com/#create-a-purchase
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -611,6 +611,23 @@ class ConvertKit_API
     }
 
     /**
+     * Retuns a specific purchase.
+     *
+     * @param integer $purchase_id Purchase ID.
+     *
+     * @return false|object
+     */
+    public function get_purchase(int $purchase_id)
+    {
+        return $this->get(
+            sprintf('purchases/%s', $purchase_id),
+            [
+                'api_secret' => $this->api_secret,
+            ]
+        );
+    }
+
+    /**
      * Creates a purchase.
      *
      * @param array<string, string> $options Purchase data.

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -593,6 +593,8 @@ class ConvertKit_API
      * List purchases.
      *
      * @param array<string, string> $options Request options.
+     * 
+     * @see https://developers.convertkit.com/#list-purchases
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *
@@ -614,6 +616,8 @@ class ConvertKit_API
      * Retuns a specific purchase.
      *
      * @param integer $purchase_id Purchase ID.
+     * 
+     * @see https://developers.convertkit.com/#retrieve-a-specific-purchase
      *
      * @return false|object
      */
@@ -631,6 +635,8 @@ class ConvertKit_API
      * Creates a purchase.
      *
      * @param array<string, string> $options Purchase data.
+     * 
+     * @see https://developers.convertkit.com/#create-a-purchase
      *
      * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
      *

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -713,6 +713,41 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that get_purchases() returns the expected data.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testGetPurchase()
+    {
+        // Get ID of first purchase.
+        $purchases = $this->api->list_purchases([
+            'page' => 1,
+        ]);
+        $id = $purchases->purchases[0]->id;
+
+        // Get purchase.
+        $result = $this->api->get_purchase($id);
+        $this->assertInstanceOf('stdClass', $result);
+        $this->assertEquals($result->id, $id);
+    }
+
+    /**
+     * Test that get_purchases() throws a ClientException when an invalid
+     * purchase ID is specified.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testGetPurchaseWithInvalidID()
+    {
+        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->api->get_purchase(12345);
+    }
+
+    /**
      * Test that create_purchase() returns the expected data.
      *
      * @since   1.0.0

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -794,6 +794,24 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that create_purchase() throws a ClientException when an invalid
+     * purchase data is specified.
+     *
+     * @since   1.0.0
+     *
+     * @return void
+     */
+    public function testCreatePurchaseWithMissingData()
+    {
+        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->api->create_purchase([
+            'invalid-key' => [
+                'transaction_id' => str_shuffle('wfervdrtgsdewrafvwefds'),
+            ],
+        ]);
+    }
+
+    /**
      * Test that fetching a legacy form's markup works.
      *
      * @since   1.0.0


### PR DESCRIPTION
## Summary

Adds a `get_purchase()` function for the [purchases API endpoint](https://developers.convertkit.com/#retrieve-a-specific-purchase).

## Testing

- `testGetPurchase`: Test that fetching a specific purchase works
- `testGetPurchaseWithInvalidID`: Test that a `ClientException` is thrown when an invalid purchase ID is specified
- `testCreatePurchaseWithMissingData`: Test that a `ClientException` is thrown when creating a purchase with invalid purchase data

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)