### PR TITLE
Update composer.json to accept monolog/monolog 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=7.4",
     "guzzlehttp/guzzle": "^6.5|^7.0",
-    "monolog/monolog": "^2.0"
+    "monolog/monolog": "^2.0|^3.0"
   },
   "require-dev": {
     "vlucas/phpdotenv": "^5.5",


### PR DESCRIPTION
## Summary

Updates composer.json to accept monolog/monolog 3.x. The fixed 2.x requirement is currently preventing this package from working with Laravel 10 and other applications that use monolog 3.x.

## Testing

There are currently no tests for the debug logging functionality, however I modified the setUp() method to enable logging with monolog 3.x installed and they passed as expected.

## Checklist

* [ ] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)