### PR TITLE
Use monolog/monolog 3.x for PHP 8.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=7.4",
     "guzzlehttp/guzzle": "^6.5|^7.0",
-    "monolog/monolog": "^2.0"
+    "monolog/monolog": "^2.0|^3.0"
   },
   "require-dev": {
     "vlucas/phpdotenv": "^5.5",

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -16,9 +16,9 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Location of the monologger log file.
-     * 
+     *
      * @since   1.2.0
-     * 
+     *
      * @var     string
      */
     protected $logFile = '';
@@ -38,7 +38,7 @@ class ConvertKitAPITest extends TestCase
         $dotenv->load();
 
         // Set location where API class will create/write the log file.
-        $this->logFile = dirname(dirname(__FILE__)).'/src/logs/debug.log';
+        $this->logFile = dirname(dirname(__FILE__)) . '/src/logs/debug.log';
 
         // Delete any existing debug log file.
         $this->deleteLogFile();
@@ -49,9 +49,9 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that debug logging works when enabled and an API call is made.
-     * 
+     *
      * @since   1.2.0
-     * 
+     *
      * @return  void
      */
     public function testDebugEnabled()
@@ -67,15 +67,15 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that debug logging is not performed when disabled and an API call is made.
-     * 
+     *
      * @since   1.2.0
-     * 
+     *
      * @return  void
      */
     public function testDebugDisabled()
     {
         $result = $this->api->get_account();
-        
+
         // Confirm that the log is empty / doesn't exist.
         $this->assertEmpty($this->getLogFileContents());
     }
@@ -2085,29 +2085,29 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Deletes the src/logs/debug.log file, if it remains following a previous test.
-     * 
+     *
      * @since   1.2.0
-     * 
+     *
      * @return  void
      */
     private function deleteLogFile()
     {
-        if(file_exists($this->logFile)) {
+        if (file_exists($this->logFile)) {
             unlink($this->logFile);
         }
     }
 
     /**
      * Returns the contents of the src/logs/debug.log file.
-     * 
+     *
      * @since   1.2.0
-     * 
+     *
      * @return  string
      */
     private function getLogFileContents()
     {
         // Return blank string if no log file.
-        if(!file_exists($this->logFile)) {
+        if (!file_exists($this->logFile)) {
             return '';
         }
 


### PR DESCRIPTION
## Summary

Permit using `monolog/monolog` `3.x` to ensure this package works with other packages that require `3.x`, such as Laravel 10, as reported [here](https://github.com/ConvertKit/ConvertKitSDK-PHP/pull/63).

PHP < 8.1 will continue to use monolog `2.x`, with our tests running in PHP 7.4 and 8.0 confirming this works.

## Testing

- `testDebugEnabled`: Test that the debug log is created and written to with expected data when debugging is enabled
- `testDebugDisabled`: Test that the debug log is not created when debugging is disabled

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)