### PR TITLE
Add `set_http_client` method

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -10,6 +10,7 @@ namespace ConvertKit_API;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Request;
 
 /**
@@ -67,9 +68,9 @@ class ConvertKit_API
     protected $debug_logger;
 
     /**
-     * Guzzle Http Client
+     * Guzzle Http ClientInterface
      *
-     * @var \GuzzleHttp\Client
+     * @var \GuzzleHttp\ClientInterface
      */
     protected $client;
 
@@ -87,7 +88,7 @@ class ConvertKit_API
         $this->api_secret = $api_secret;
         $this->debug      = $debug;
 
-        // Specify a User-Agent for API requests.
+        // Set the Guzzle client.
         $this->client = new Client(
             [
                 'headers' => [
@@ -103,6 +104,20 @@ class ConvertKit_API
                 $stream_handler // phpcs:ignore Squiz.Objects.ObjectInstantiation.NotAssigned
             );
         }
+    }
+
+    /**
+     * Set the Guzzle client implementation to use for API requests.
+     *
+     * @param ClientInterface $client Guzzle client implementation.
+     *
+     * @since 1.3.0
+     *
+     * @return void
+     */
+    public function set_http_client(ClientInterface $client)
+    {
+        $this->client = $client;
     }
 
     /**


### PR DESCRIPTION
## Summary

Allows users to define their own HTTP client compatible with `ClientInterface`.

Implementation of [this PR](https://github.com/ConvertKit/ConvertKitSDK-PHP/pull/65), with tests now passing.

## Testing

- `testClientInterfaceInjection()`: Injects a GuzzleHttp\Handler\MockHandler and asserts the results are as expected when mocking an API request.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)