### PR TITLE
Move Namespaces to `use` Statements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
 
     # Defines PHP Versions matrix to run tests on
     strategy:
+      fail-fast: false
       matrix:
         php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
 

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -7,6 +7,9 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ClientException;
+use Dotenv\Dotenv;
+use ConvertKit_API\ConvertKit_API;
 
 /**
  * ConvertKit API class tests.
@@ -40,7 +43,7 @@ class ConvertKitAPITest extends TestCase
     protected function setUp(): void
     {
         // Load environment credentials from root folder.
-        $dotenv = Dotenv\Dotenv::createImmutable(dirname(dirname(__FILE__)));
+        $dotenv = Dotenv::createImmutable(dirname(dirname(__FILE__)));
         $dotenv->load();
 
         // Set location where API class will create/write the log file.
@@ -50,7 +53,7 @@ class ConvertKitAPITest extends TestCase
         $this->deleteLogFile();
 
         // Setup API.
-        $this->api = new \ConvertKit_API\ConvertKit_API($_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET']);
+        $this->api = new ConvertKit_API($_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET']);
     }
 
     /**
@@ -99,7 +102,7 @@ class ConvertKitAPITest extends TestCase
     public function testDebugEnabled()
     {
         // Setup API with debugging enabled.
-        $api = new \ConvertKit_API\ConvertKit_API($_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], true);
+        $api = new ConvertKit_API($_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], true);
         $result = $api->get_account();
 
         // Confirm that the log includes expected data.
@@ -121,7 +124,7 @@ class ConvertKitAPITest extends TestCase
         $this->logFile = dirname(dirname(__FILE__)) . '/src/logs/debug-custom.log';
 
         // Setup API with debugging enabled.
-        $api = new \ConvertKit_API\ConvertKit_API(
+        $api = new ConvertKit_API(
             $_ENV['CONVERTKIT_API_KEY'],
             $_ENV['CONVERTKIT_API_SECRET'],
             true,
@@ -148,7 +151,7 @@ class ConvertKitAPITest extends TestCase
     public function testDebugAPIKeyAndSecretAreMasked()
     {
         // Setup API with debugging enabled.
-        $api = new \ConvertKit_API\ConvertKit_API($_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], true);
+        $api = new ConvertKit_API($_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], true);
 
         // Make requests that utilizes both the API Key and Secret.
         $api->get_forms(); // API Key.
@@ -200,8 +203,8 @@ class ConvertKitAPITest extends TestCase
      */
     public function testInvalidAPICredentials()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
-        $api = new \ConvertKit_API\ConvertKit_API('fakeApiKey', 'fakeApiSecret');
+        $this->expectException(ClientException::class);
+        $api = new ConvertKit_API('fakeApiKey', 'fakeApiSecret');
         $result = $api->get_account();
     }
 
@@ -382,7 +385,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetFormSubscriptionsWithInvalidFormID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->get_form_subscriptions(12345);
     }
 
@@ -434,7 +437,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testAddSubscriberToSequenceWithInvalidSequenceID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->add_subscriber_to_sequence(12345, $this->generateEmailAddress());
     }
 
@@ -448,7 +451,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testAddSubscriberToSequenceWithInvalidEmailAddress()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->add_subscriber_to_sequence($_ENV['CONVERTKIT_API_SEQUENCE_ID'], 'not-an-email-address');
     }
 
@@ -603,7 +606,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetSequenceSubscriptionsWithInvalidSortOrder()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->get_sequence_subscriptions($_ENV['CONVERTKIT_API_SEQUENCE_ID'], 'invalidSortOrder');
     }
 
@@ -617,7 +620,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetSequenceSubscriptionsWithInvalidSequenceID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->get_sequence_subscriptions(12345);
     }
 
@@ -670,7 +673,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testCreateTagBlank()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->create_tag('');
     }
 
@@ -684,7 +687,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testCreateTagThatExists()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->create_tag($_ENV['CONVERTKIT_API_TAG_NAME']);
     }
 
@@ -724,7 +727,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testCreateTagsBlank()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->create_tags([
             '',
             '',
@@ -741,7 +744,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testCreateTagsThatExist()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->create_tags([
             $_ENV['CONVERTKIT_API_TAG_NAME'],
             $_ENV['CONVERTKIT_API_TAG_NAME_2'],
@@ -860,7 +863,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testRemoveTagFromSubscriberWithInvalidTagID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->remove_tag_from_subscriber(
             12345,
             $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
@@ -877,7 +880,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testRemoveTagFromSubscriberWithInvalidSubscriberID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->remove_tag_from_subscriber(
             (int) $_ENV['CONVERTKIT_API_TAG_ID'],
             12345
@@ -925,7 +928,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testRemoveTagFromSubscriberByEmailWithInvalidTagID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->remove_tag_from_subscriber_by_email(
             12345,
             $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
@@ -1041,7 +1044,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetTagSubscriptionsWithInvalidFormID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->get_tag_subscriptions(12345);
     }
 
@@ -1111,7 +1114,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetResourcesInvalidResourceType()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->get_resources('invalid-resource-type');
         $this->assertIsArray($result);
     }
@@ -1149,7 +1152,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testAddSubscriberToFormWithInvalidFormID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->add_subscriber_to_form(12345, $this->generateEmailAddress());
     }
 
@@ -1163,7 +1166,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testAddSubscriberToFormWithInvalidEmailAddress()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $result = $this->api->add_subscriber_to_form($_ENV['CONVERTKIT_API_FORM_ID'], 'not-an-email-address');
     }
 
@@ -1275,7 +1278,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetSubscriberIDWithInvalidEmailAddress()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $result = $this->api->get_subscriber_id('not-an-email-address');
     }
 
@@ -1322,7 +1325,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetSubscriberWithInvalidSubscriberID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $subscriber = $this->api->get_subscriber(12345);
     }
 
@@ -1466,7 +1469,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testUpdateSubscriberWithInvalidSubscriberID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $subscriber = $this->api->update_subscriber(12345);
     }
 
@@ -1506,7 +1509,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testUnsubscribeWithNotSubscribedEmailAddress()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $subscriber = $this->api->unsubscribe('not-subscribed@convertkit.com');
     }
 
@@ -1520,7 +1523,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testUnsubscribeWithInvalidEmailAddress()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $subscriber = $this->api->unsubscribe('invalid-email');
     }
 
@@ -1548,7 +1551,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetSubscriberTagsWithInvalidSubscriberID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $subscriber = $this->api->get_subscriber_tags(12345);
     }
 
@@ -1619,9 +1622,9 @@ class ConvertKitAPITest extends TestCase
     public function testCreateAndDestroyPublicBroadcastWithValidDates()
     {
         // Create DateTime object.
-        $publishedAt = new \DateTime('now');
+        $publishedAt = new DateTime('now');
         $publishedAt->modify('+7 days');
-        $sendAt = new \DateTime('now');
+        $sendAt = new DateTime('now');
         $sendAt->modify('+14 days');
 
         // Create a broadcast first.
@@ -1678,7 +1681,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetBroadcastWithInvalidBroadcastID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $this->api->get_broadcast(12345);
     }
 
@@ -1712,7 +1715,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetBroadcastStatsWithInvalidBroadcastID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $this->api->get_broadcast_stats(12345);
     }
 
@@ -1726,7 +1729,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testUpdateBroadcastWithInvalidBroadcastID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $this->api->update_broadcast(12345);
     }
 
@@ -1740,7 +1743,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testDestroyBroadcastWithInvalidBroadcastID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $this->api->destroy_broadcast(12345);
     }
 
@@ -1803,7 +1806,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testCreateWebhookWithInvalidEvent()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->api->create_webhook('https://webhook.site/2705fef6-34ef-4252-9c78-d511c540b58d', 'invalid.event');
     }
 
@@ -1817,7 +1820,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testDestroyWebhookWithInvalidRuleID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $this->api->destroy_webhook(12345);
     }
 
@@ -1875,7 +1878,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testCreateCustomFieldWithBlankLabel()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $this->api->create_custom_field('');
     }
 
@@ -1952,7 +1955,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testUpdateCustomFieldWithInvalidID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $this->api->update_custom_field(12345, 'Something');
     }
 
@@ -1990,7 +1993,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testDeleteCustomFieldWithInvalidID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $this->api->delete_custom_field(12345);
     }
 
@@ -2044,7 +2047,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetPurchaseWithInvalidID()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $this->api->get_purchase(12345);
     }
 
@@ -2104,7 +2107,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testCreatePurchaseWithMissingData()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $this->api->create_purchase([
             'invalid-key' => [
                 'transaction_id' => str_shuffle('wfervdrtgsdewrafvwefds'),
@@ -2176,7 +2179,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetResourceInvalidURL()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $markup = $this->api->get_resource('not-a-url');
     }
 
@@ -2190,7 +2193,7 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetResourceInaccessibleURL()
     {
-        $this->expectException(GuzzleHttp\Exception\ClientException::class);
+        $this->expectException(ClientException::class);
         $markup = $this->api->get_resource('https://convertkit.com/a/url/that/does/not/exist');
     }
 


### PR DESCRIPTION
## Summary

Tidies up test code by adding `use statements` for `ClientException`, `Dotenv` and the `ConvertKit_API` classes.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)