### PR TITLE
v4 API: Accounts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,7 @@ jobs:
             CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA=${{ secrets.CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA }}
             CONVERTKIT_OAUTH_CLIENT_ID=${{ secrets.CONVERTKIT_OAUTH_CLIENT_ID }}
             CONVERTKIT_OAUTH_CLIENT_SECRET=${{ secrets.CONVERTKIT_OAUTH_CLIENT_SECRET }}
+            CONVERTKIT_OAUTH_REDIRECT_URI=${{ secrets.CONVERTKIT_OAUTH_REDIRECT_URI }}
           write-mode: append
 
       # Rename .env.dist.testing to .env, so PHPUnit reads it for tests.

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -272,13 +272,25 @@ class ConvertKit_API
     /**
      * Gets the current account
      *
-     * @see https://developers.convertkit.com/#account
+     * @see https://developers.convertkit.com/v4.html#get-current-account
      *
      * @return false|mixed
      */
     public function get_account()
     {
         return $this->get('account');
+    }
+
+    /**
+     * Gets the account's colors
+     *
+     * @see https://developers.convertkit.com/v4.html#list-colors
+     *
+     * @return false|mixed
+     */
+    public function get_account_colors()
+    {
+        return $this->get('account/colors');
     }
 
     /**

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -322,6 +322,18 @@ class ConvertKit_API
     }
 
     /**
+     * Gets email stats
+     *
+     * @see https://developers.convertkit.com/v4.html#get-email-stats
+     *
+     * @return false|mixed
+     */
+    public function get_email_stats()
+    {
+        return $this->get('account/email_stats');
+    }
+
+    /**
      * Gets all forms.
      *
      * @since 1.0.0

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -310,6 +310,18 @@ class ConvertKit_API
     }
 
     /**
+     * Gets the Creator Profile
+     *
+     * @see https://developers.convertkit.com/v4.html#get-creator-profile
+     *
+     * @return false|mixed
+     */
+    public function get_creator_profile()
+    {
+        return $this->get('account/creator_profile');
+    }
+
+    /**
      * Gets all forms.
      *
      * @since 1.0.0

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -283,7 +283,7 @@ class ConvertKit_API
      *
      * @see https://developers.convertkit.com/v4.html#list-colors
      *
-     * @return array
+     * @return false|mixed
      */
     public function get_account_colors()
     {
@@ -293,19 +293,17 @@ class ConvertKit_API
     /**
      * Gets the account's colors
      *
-     * @see https://developers.convertkit.com/v4.html#list-colors
-     * 
      * @param array<string, string> $colors Hex colors.
      *
-     * @return array
+     * @see https://developers.convertkit.com/v4.html#list-colors
+     *
+     * @return false|mixed
      */
     public function update_account_colors(array $colors)
     {
         return $this->put(
             endpoint: 'account/colors',
-            args: [
-                'colors' => $colors,
-            ]
+            args: ['colors' => $colors]
         );
     }
 
@@ -336,18 +334,22 @@ class ConvertKit_API
     /**
      * Gets growth stats
      *
-     * @see https://developers.convertkit.com/v4.html#get-growth-stats
-     *
      * @param \DateTime $starting Gets stats for time period beginning on this date. Defaults to 90 days ago.
      * @param \DateTime $ending   Gets stats for time period ending on this date. Defaults to today.
+     *
+     * @see https://developers.convertkit.com/v4.html#get-growth-stats
+     *
      * @return false|mixed
      */
     public function get_growth_stats(\DateTime $starting = null, \DateTime $ending = null)
     {
-        return $this->get('account/growth_stats', [
-            'starting' => (!is_null($starting) ? $starting->format('Y-m-d') : ''),
-            'ending' => (!is_null($ending) ? $ending->format('Y-m-d') : ''),
-        ]);
+        return $this->get(
+            'account/growth_stats',
+            [
+                'starting' => (!is_null($starting) ? $starting->format('Y-m-d') : ''),
+                'ending'   => (!is_null($ending) ? $ending->format('Y-m-d') : ''),
+            ]
+        );
     }
 
     /**

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -334,6 +334,23 @@ class ConvertKit_API
     }
 
     /**
+     * Gets growth stats
+     *
+     * @see https://developers.convertkit.com/v4.html#get-growth-stats
+     *
+     * @param \DateTime $starting Gets stats for time period beginning on this date. Defaults to 90 days ago.
+     * @param \DateTime $ending   Gets stats for time period ending on this date. Defaults to today.
+     * @return false|mixed
+     */
+    public function get_growth_stats(\DateTime $starting = null, \DateTime $ending = null)
+    {
+        return $this->get('account/growth_stats', [
+            'starting' => (!is_null($starting) ? $starting->format('Y-m-d') : ''),
+            'ending' => (!is_null($ending) ? $ending->format('Y-m-d') : ''),
+        ]);
+    }
+
+    /**
      * Gets all forms.
      *
      * @since 1.0.0

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -286,11 +286,30 @@ class ConvertKit_API
      *
      * @see https://developers.convertkit.com/v4.html#list-colors
      *
-     * @return false|mixed
+     * @return array
      */
     public function get_account_colors()
     {
         return $this->get('account/colors');
+    }
+
+    /**
+     * Gets the account's colors
+     *
+     * @see https://developers.convertkit.com/v4.html#list-colors
+     * 
+     * @param array<string, string> $colors Hex colors.
+     *
+     * @return array
+     */
+    public function update_account_colors(array $colors)
+    {
+        return $this->put(
+            endpoint: 'account/colors',
+            args: [
+                'colors' => $colors,
+            ]
+        );
     }
 
     /**
@@ -1596,38 +1615,11 @@ class ConvertKit_API
         }
 
         // Build request.
-        switch ($method) {
-            case 'GET':
-                if ($args) {
-                    $url .= '?' . http_build_query($args);
-                }
-
-                $request = new Request(
-                    $method,
-                    $url,
-                    [
-                        'headers' => [
-                            'Content-Type'   => 'application/json',
-                            'Content-Length' => strlen($request_body),
-                        ],
-                    ],
-                );
-                break;
-
-            default:
-                $request = new Request(
-                    $method,
-                    $url,
-                    [
-                        'headers' => [
-                            'Content-Type'   => 'application/json',
-                            'Content-Length' => strlen($request_body),
-                        ],
-                    ],
-                    $request_body
-                );
-                break;
-        }//end switch
+        $request = new Request(
+            method: $method,
+            uri:    $url,
+            body:   $request_body
+        );
 
         // Send request.
         $response = $this->client->send(

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -520,8 +520,8 @@ class ConvertKitAPITest extends TestCase
         $this->assertArrayHasKey('ending', $stats);
 
         // Assert start and end dates were honored.
-        $this->assertEquals($stats['starting'], $starting->format('Y-m-d').'T00:00:00-04:00');
-        $this->assertEquals($stats['ending'], $ending->format('Y-m-d').'T23:59:59-04:00');
+        $this->assertEquals($stats['starting'], $starting->format('Y-m-d') . 'T00:00:00-04:00');
+        $this->assertEquals($stats['ending'], $ending->format('Y-m-d') . 'T23:59:59-04:00');
     }
 
     /**
@@ -557,8 +557,8 @@ class ConvertKitAPITest extends TestCase
         $this->assertArrayHasKey('ending', $stats);
 
         // Assert start and end dates were honored.
-        $this->assertEquals($stats['starting'], $starting->format('Y-m-d').'T00:00:00-04:00');
-        $this->assertEquals($stats['ending'], $ending->format('Y-m-d').'T23:59:59-04:00');
+        $this->assertEquals($stats['starting'], $starting->format('Y-m-d') . 'T00:00:00-04:00');
+        $this->assertEquals($stats['ending'], $ending->format('Y-m-d') . 'T23:59:59-04:00');
     }
 
     /**

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -404,6 +404,29 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that update_account_colors() returns the expected data.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testUpdateAccountColors()
+    {
+        $result = $this->api->update_account_colors([
+            '#111111',
+            '#222222',
+        ]);
+        var_dump($result);
+        die();
+        $this->assertInstanceOf('stdClass', $result);
+
+        // Convert to array to check for keys, as assertObjectHasAttribute() will be deprecated in PHPUnit 10.
+        $result = get_object_vars($result);
+        $this->assertArrayHasKey('colors', $result);
+        $this->assertIsArray($result['colors']);
+    }
+
+    /**
      * Test that get_forms() returns the expected data.
      *
      * @since   1.0.0

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -386,6 +386,24 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that get_account_colors() returns the expected data.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetAccountColors()
+    {
+        $result = $this->api->get_account_colors();
+        $this->assertInstanceOf('stdClass', $result);
+
+        // Convert to array to check for keys, as assertObjectHasAttribute() will be deprecated in PHPUnit 10.
+        $result = get_object_vars($result);
+        $this->assertArrayHasKey('colors', $result);
+        $this->assertIsArray($result['colors']);
+    }
+
+    /**
      * Test that get_forms() returns the expected data.
      *
      * @since   1.0.0

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -402,7 +402,7 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
-     * Test that update_account_colors() returns the expected data.
+     * Test that update_account_colors() updates the account's colors.
      *
      * @since   2.0.0
      *

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -467,6 +467,101 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that get_growth_stats() returns the expected data.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetGrowthStats()
+    {
+        $result = $this->api->get_growth_stats();
+        $this->assertInstanceOf('stdClass', $result);
+
+        $result = get_object_vars($result);
+        $stats = get_object_vars($result['stats']);
+        $this->assertArrayHasKey('cancellations', $stats);
+        $this->assertArrayHasKey('net_new_subscribers', $stats);
+        $this->assertArrayHasKey('new_subscribers', $stats);
+        $this->assertArrayHasKey('subscribers', $stats);
+        $this->assertArrayHasKey('starting', $stats);
+        $this->assertArrayHasKey('ending', $stats);
+    }
+
+    /**
+     * Test that get_growth_stats() returns the expected data
+     * when a start date is specified.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetGrowthStatsWithStartDate()
+    {
+        // Define start and end dates.
+        $starting = new DateTime('now');
+        $starting->modify('-7 days');
+        $ending = new DateTime('now');
+
+        // Send request.
+        $result = $this->api->get_growth_stats(
+            starting: $starting
+        );
+        $this->assertInstanceOf('stdClass', $result);
+
+        // Confirm response object contains expected keys.
+        $result = get_object_vars($result);
+        $stats = get_object_vars($result['stats']);
+        $this->assertArrayHasKey('cancellations', $stats);
+        $this->assertArrayHasKey('net_new_subscribers', $stats);
+        $this->assertArrayHasKey('new_subscribers', $stats);
+        $this->assertArrayHasKey('subscribers', $stats);
+        $this->assertArrayHasKey('starting', $stats);
+        $this->assertArrayHasKey('ending', $stats);
+
+        // Assert start and end dates were honored.
+        $this->assertEquals($stats['starting'], $starting->format('Y-m-d').'T00:00:00-04:00');
+        $this->assertEquals($stats['ending'], $ending->format('Y-m-d').'T23:59:59-04:00');
+    }
+
+    /**
+     * Test that get_growth_stats() returns the expected data
+     * when an end date is specified.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetGrowthStatsWithEndDate()
+    {
+        // Define start and end dates.
+        $starting = new DateTime('now');
+        $starting->modify('-90 days');
+        $ending = new DateTime('now');
+        $ending->modify('-7 days');
+
+        // Send request.
+        $result = $this->api->get_growth_stats(
+            ending: $ending
+        );
+        $this->assertInstanceOf('stdClass', $result);
+
+        // Confirm response object contains expected keys.
+        $result = get_object_vars($result);
+        $stats = get_object_vars($result['stats']);
+        $this->assertArrayHasKey('cancellations', $stats);
+        $this->assertArrayHasKey('net_new_subscribers', $stats);
+        $this->assertArrayHasKey('new_subscribers', $stats);
+        $this->assertArrayHasKey('subscribers', $stats);
+        $this->assertArrayHasKey('starting', $stats);
+        $this->assertArrayHasKey('ending', $stats);
+
+        // Assert start and end dates were honored.
+        $this->assertEquals($stats['starting'], $starting->format('Y-m-d').'T00:00:00-04:00');
+        $this->assertEquals($stats['ending'], $ending->format('Y-m-d').'T23:59:59-04:00');
+    }
+
+    /**
      * Test that get_forms() returns the expected data.
      *
      * @since   1.0.0

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -414,16 +414,14 @@ class ConvertKitAPITest extends TestCase
     {
         $result = $this->api->update_account_colors([
             '#111111',
-            '#222222',
         ]);
-        var_dump($result);
-        die();
         $this->assertInstanceOf('stdClass', $result);
 
         // Convert to array to check for keys, as assertObjectHasAttribute() will be deprecated in PHPUnit 10.
         $result = get_object_vars($result);
         $this->assertArrayHasKey('colors', $result);
         $this->assertIsArray($result['colors']);
+        $this->assertEquals($result['colors'][0], '#111111');
     }
 
     /**

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -374,12 +374,11 @@ class ConvertKitAPITest extends TestCase
         $result = $this->api->get_account();
         $this->assertInstanceOf('stdClass', $result);
 
-        // Convert to array to check for keys, as assertObjectHasAttribute() will be deprecated in PHPUnit 10.
         $result = get_object_vars($result);
-        $account = get_object_vars($result['account']);
-        $this->assertIsArray($result);
         $this->assertArrayHasKey('user', $result);
         $this->assertArrayHasKey('account', $result);
+
+        $account = get_object_vars($result['account']);
         $this->assertArrayHasKey('name', $account);
         $this->assertArrayHasKey('plan_type', $account);
         $this->assertArrayHasKey('primary_email_address', $account);
@@ -397,7 +396,6 @@ class ConvertKitAPITest extends TestCase
         $result = $this->api->get_account_colors();
         $this->assertInstanceOf('stdClass', $result);
 
-        // Convert to array to check for keys, as assertObjectHasAttribute() will be deprecated in PHPUnit 10.
         $result = get_object_vars($result);
         $this->assertArrayHasKey('colors', $result);
         $this->assertIsArray($result['colors']);
@@ -417,11 +415,31 @@ class ConvertKitAPITest extends TestCase
         ]);
         $this->assertInstanceOf('stdClass', $result);
 
-        // Convert to array to check for keys, as assertObjectHasAttribute() will be deprecated in PHPUnit 10.
         $result = get_object_vars($result);
         $this->assertArrayHasKey('colors', $result);
         $this->assertIsArray($result['colors']);
         $this->assertEquals($result['colors'][0], '#111111');
+    }
+
+    /**
+     * Test that get_creator_profile() returns the expected data.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetCreatorProfile()
+    {
+        $result = $this->api->get_creator_profile();
+        $this->assertInstanceOf('stdClass', $result);
+
+        $result = get_object_vars($result);
+        $profile = get_object_vars($result['profile']);
+        $this->assertArrayHasKey('name', $profile);
+        $this->assertArrayHasKey('byline', $profile);
+        $this->assertArrayHasKey('bio', $profile);
+        $this->assertArrayHasKey('image_url', $profile);
+        $this->assertArrayHasKey('profile_url', $profile);
     }
 
     /**

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -443,6 +443,30 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that get_email_stats() returns the expected data.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetEmailStats()
+    {
+        $result = $this->api->get_email_stats();
+        $this->assertInstanceOf('stdClass', $result);
+
+        $result = get_object_vars($result);
+        $stats = get_object_vars($result['stats']);
+        $this->assertArrayHasKey('sent', $stats);
+        $this->assertArrayHasKey('clicked', $stats);
+        $this->assertArrayHasKey('opened', $stats);
+        $this->assertArrayHasKey('email_stats_mode', $stats);
+        $this->assertArrayHasKey('open_tracking_enabled', $stats);
+        $this->assertArrayHasKey('click_tracking_enabled', $stats);
+        $this->assertArrayHasKey('starting', $stats);
+        $this->assertArrayHasKey('ending', $stats);
+    }
+
+    /**
      * Test that get_forms() returns the expected data.
      *
      * @since   1.0.0


### PR DESCRIPTION
## Summary

Adds support for endpoints in the accounts section of the v4 API.

## Testing

- `testGetAccountColors`: Test that `get_account_colors()` returns the expected data.
- `testUpdateAccountColors`: Test that `update_account_colors()` updates the account's colors.
- `testGetCreatorProfile`: Test that `get_creator_profile()` returns the expected data.
- `testGetEmailStats`: Test that `get_email_stats()` returns the expected data.
- `testGetGrowthStats`: Test that `get_growth_stats()` returns the expected data.
- `testGetGrowthStatsWithStartDate`: Test that `get_growth_stats()` returns the expected data when a start date is specified.
- `testGetGrowthStatsWithEndDate`: Test that `get_growth_stats()` returns the expected data when an end date is specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)