### PR TITLE
v4 API: Forms

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -309,8 +309,8 @@ class ConvertKit_API
     /**
      * Adds a subscriber to a form by email address
      *
-     * @param integer               $form_id    Form ID.
-     * @param string                $email      Email Address.
+     * @param integer $form_id Form ID.
+     * @param string  $email   Email Address.
      *
      * @see https://developers.convertkit.com/v4.html#add-subscriber-to-form-by-email-address
      *
@@ -320,21 +320,19 @@ class ConvertKit_API
     {
         return $this->post(
             endpoint: sprintf('forms/%s/subscribers', $form_id),
-            args: [
-                'email_address' => $email,
-            ]
+            args: ['email_address' => $email]
         );
     }
 
     /**
      * Adds a subscriber to a form by subscriber ID
      *
-     * @param integer   $form_id        Form ID.
-     * @param integer   $subscriber_id  Subscriber ID.
+     * @param integer $form_id       Form ID.
+     * @param integer $subscriber_id Subscriber ID.
      *
      * @see https://developers.convertkit.com/v4.html#add-subscriber-to-form
-     * 
-     * @since  2.0.0
+     *
+     * @since 2.0.0
      *
      * @return false|mixed
      */
@@ -346,10 +344,15 @@ class ConvertKit_API
     /**
      * List subscribers for a form
      *
-     * @param integer $form_id          Form ID.
-     * @param string  $subscriber_state Subscriber State (active|bounced|cancelled|complained|inactive).
-     * @param 
-     * @param integer $page             Page.
+     * @param integer   $form_id          Form ID.
+     * @param string    $subscriber_state Subscriber State (active|bounced|cancelled|complained|inactive).
+     * @param \DateTime $created_after    Filter subscribers who have been created after this date.
+     * @param \DateTime $created_before   Filter subscribers who have been created before this date.
+     * @param \DateTime $added_after      Filter subscribers who have been added to the form after this date.
+     * @param \DateTime $added_before     Filter subscribers who have been added to the form before this date.
+     * @param string    $after_cursor     Return results after the given pagination cursor.
+     * @param string    $before_cursor    Return results before the given pagination cursor.
+     * @param integer   $per_page         Number of results to return.
      *
      * @see https://developers.convertkit.com/v4.html#list-subscribers-for-a-form
      *
@@ -392,7 +395,7 @@ class ConvertKit_API
             before_cursor: $before_cursor,
             per_page: $per_page
         );
-        
+
         // Send request.
         return $this->get(
             endpoint: sprintf('forms/%s/subscribers', $form_id),
@@ -1482,11 +1485,16 @@ class ConvertKit_API
     }
 
     /**
-     * Adds pagination parameters to the given array of existing parameters.
-     * 
-     * @since   2.0.0
-     * 
-     * @return  array
+     * Adds pagination parameters to the given array of existing API parameters.
+     *
+     * @param array<string, string|integer> $params        API parameters.
+     * @param string                        $after_cursor  Return results after the given pagination cursor.
+     * @param string                        $before_cursor Return results before the given pagination cursor.
+     * @param integer                       $per_page      Number of results to return.
+     *
+     * @since 2.0.0
+     *
+     * @return array<string, string|integer>
      */
     private function build_pagination_params(
         array $params,

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -307,99 +307,96 @@ class ConvertKit_API
     }
 
     /**
-     * Adds a subscriber to a form.
-     *
-     * @param integer               $form_id Form ID.
-     * @param array<string, string> $options Array of user data (email, name).
-     *
-     * @deprecated 1.0.0 Use add_subscriber_to_form($form_id, $email, $first_name, $fields, $tag_ids).
-     *
-     * @throws \InvalidArgumentException If the provided arguments are not of the expected type.
-     *
-     * @see https://developers.convertkit.com/#add-subscriber-to-a-form
-     *
-     * @return false|object
-     */
-    public function form_subscribe(int $form_id, array $options)
-    {
-        // This function is deprecated in 1.0, as we prefer functions with structured arguments.
-        trigger_error(
-            'form_subscribe() is deprecated in 1.0.
-            Use add_subscriber_to_form($form_id, $email, $first_name, $fields, $tag_ids) instead.',
-            E_USER_NOTICE
-        );
-
-        return $this->post(
-            sprintf('forms/%s/subscribe', $form_id),
-            $options
-        );
-    }
-
-    /**
      * Adds a subscriber to a form by email address
      *
      * @param integer               $form_id    Form ID.
      * @param string                $email      Email Address.
-     * @param string                $first_name First Name.
-     * @param array<string, string> $fields     Custom Fields.
-     * @param array<string, int>    $tag_ids    Tag ID(s) to subscribe to.
      *
-     * @see https://developers.convertkit.com/#add-subscriber-to-a-form
+     * @see https://developers.convertkit.com/v4.html#add-subscriber-to-form-by-email-address
      *
      * @return false|mixed
      */
-    public function add_subscriber_to_form(
-        int $form_id,
-        string $email,
-        string $first_name = '',
-        array $fields = [],
-        array $tag_ids = []
-    ) {
-        // Build parameters.
-        $options = ['email' => $email];
-
-        if (!empty($first_name)) {
-            $options['first_name'] = $first_name;
-        }
-        if (!empty($fields)) {
-            $options['fields'] = $fields;
-        }
-        if (!empty($tag_ids)) {
-            $options['tags'] = $tag_ids;
-        }
-
-        // Send request.
+    public function add_subscriber_to_form(int $form_id, string $email)
+    {
         return $this->post(
-            sprintf('forms/%s/subscribe', $form_id),
-            $options
+            endpoint: sprintf('forms/%s/subscribers', $form_id),
+            args: [
+                'email_address' => $email,
+            ]
         );
     }
 
     /**
-     * List subscriptions to a form
+     * Adds a subscriber to a form by subscriber ID
+     *
+     * @param integer   $form_id        Form ID.
+     * @param integer   $subscriber_id  Subscriber ID.
+     *
+     * @see https://developers.convertkit.com/v4.html#add-subscriber-to-form
+     * 
+     * @since  2.0.0
+     *
+     * @return false|mixed
+     */
+    public function add_subscriber_to_form_by_subscriber_id(int $form_id, int $subscriber_id)
+    {
+        return $this->post(sprintf('forms/%s/subscribers/%s', $form_id, $subscriber_id));
+    }
+
+    /**
+     * List subscribers for a form
      *
      * @param integer $form_id          Form ID.
-     * @param string  $sort_order       Sort Order (asc|desc).
      * @param string  $subscriber_state Subscriber State (active,cancelled).
+     * @param 
      * @param integer $page             Page.
      *
-     * @see https://developers.convertkit.com/#list-subscriptions-to-a-form
+     * @see https://developers.convertkit.com/v4.html#list-subscribers-for-a-form
      *
      * @return false|mixed
      */
     public function get_form_subscriptions(
         int $form_id,
-        string $sort_order = 'asc',
         string $subscriber_state = 'active',
-        int $page = 1
+        \DateTime $created_after = null,
+        \DateTime $created_before = null,
+        \DateTime $added_after = null,
+        \DateTime $added_before = null,
+        string $after_cursor = '',
+        string $before_cursor = '',
+        int $per_page = 100
     ) {
+        // Build parameters.
+        $options = [];
+
+        if (!empty($subscriber_status)) {
+            $options['status'] = $subscriber_status;
+        }
+        if (!is_null($created_after)) {
+            $options['created_after'] = $created_after->format('Y-m-d');
+        }
+        if (!is_null($created_before)) {
+            $options['created_before'] = $created_before->format('Y-m-d');
+        }
+        if (!is_null($added_after)) {
+            $options['added_after'] = $added_after->format('Y-m-d');
+        }
+        if (!is_null($added_before)) {
+            $options['added_before'] = $added_before->format('Y-m-d');
+        }
+
+        // Build pagination parameters.
+        $options = $this->build_pagination_params(
+            params: $options,
+            after_cursor: $after_cursor,
+            before_cursor: $before_cursor,
+            per_page: $per_page
+        );
+        
+        // Send request.
         return $this->get(
-            sprintf('forms/%s/subscriptions', $form_id),
-            [
-                'sort_order'       => $sort_order,
-                'subscriber_state' => $subscriber_state,
-                'page'             => $page,
-            ]
+            endpoint: sprintf('forms/%s/subscribers', $form_id),
+            args: $options
         );
     }
 
@@ -1482,6 +1479,32 @@ class ConvertKit_API
         $markup = str_replace('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', '', $markup);
 
         return $markup;
+    }
+
+    /**
+     * Adds pagination parameters to the given array of existing parameters.
+     * 
+     * @since   2.0.0
+     * 
+     * @return  array
+     */
+    private function build_pagination_params(
+        array $params,
+        string $after_cursor = '',
+        string $before_cursor = '',
+        int $per_page = 100
+    ) {
+        if (!empty($after_cursor)) {
+            $params['after'] = $after_cursor;
+        }
+        if (!empty($before_cursor)) {
+            $params['before'] = $before_cursor;
+        }
+        if (!empty($per_page)) {
+            $params['per_page'] = $per_page;
+        }
+
+        return $params;
     }
 
     /**

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -347,7 +347,7 @@ class ConvertKit_API
      * List subscribers for a form
      *
      * @param integer $form_id          Form ID.
-     * @param string  $subscriber_state Subscriber State (active,cancelled).
+     * @param string  $subscriber_state Subscriber State (active|bounced|cancelled|complained|inactive).
      * @param 
      * @param integer $page             Page.
      *
@@ -369,8 +369,8 @@ class ConvertKit_API
         // Build parameters.
         $options = [];
 
-        if (!empty($subscriber_status)) {
-            $options['status'] = $subscriber_status;
+        if (!empty($subscriber_state)) {
+            $options['status'] = $subscriber_state;
         }
         if (!is_null($created_after)) {
             $options['created_after'] = $created_after->format('Y-m-d');

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -448,12 +448,8 @@ class ConvertKitAPITest extends TestCase
             form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID']
         );
 
-        // Assert subscribers exist.
-        $result = get_object_vars($result);
-        $this->assertArrayHasKey('subscribers', $result);
-        $this->assertIsArray($result['subscribers']);
-
-        // Assert pagination exists.
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
         $this->assertPaginationExists($result);
     }
 
@@ -473,19 +469,113 @@ class ConvertKitAPITest extends TestCase
             subscriber_state: 'bounced'
         );
 
-        // Assert subscribers exist.
-        $result = get_object_vars($result);
-        $this->assertArrayHasKey('subscribers', $result);
-        $this->assertIsArray($result['subscribers']);
-
-        // Check they are cancelled.
-        $this->assertEquals($result['subscribers'][0]->state, 'bounced');
-
-        // Assert pagination exists.
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
         $this->assertPaginationExists($result);
+
+        // Check the correct subscribers were returned.
+        $this->assertEquals($result->subscribers[0]->state, 'bounced');
     }
 
-    // @TODO Test Added_After, added_before, created_after, created_before, pagination (per_page, after, before)
+    /**
+     * Test that get_form_subscriptions() returns the expected data
+     * when a valid Form ID is specified and the added_after parameter
+     * is used.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetFormSubscriptionsWithAddedAfterParam()
+    {
+        $date = new \DateTime('2024-01-01');
+        $result = $this->api->get_form_subscriptions(
+            form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+            added_after: $date
+        );
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
+
+        // Check the correct subscribers were returned.
+        $this->assertGreaterThanOrEqual($date->format('Y-m-d'), date('Y-m-d', strtotime($result->subscribers[0]->added_at)));
+    }
+
+    /**
+     * Test that get_form_subscriptions() returns the expected data
+     * when a valid Form ID is specified and the added_before parameter
+     * is used.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetFormSubscriptionsWithAddedBeforeParam()
+    {
+        $date = new \DateTime('2024-01-01');
+        $result = $this->api->get_form_subscriptions(
+            form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+            added_before: $date
+        );
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
+
+        // Check the correct subscribers were returned.
+        $this->assertLessThanOrEqual($date->format('Y-m-d'), date('Y-m-d', strtotime($result->subscribers[0]->added_at)));
+    }
+
+    /**
+     * Test that get_form_subscriptions() returns the expected data
+     * when a valid Form ID is specified and the created_after parameter
+     * is used.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetFormSubscriptionsWithCreatedAfterParam()
+    {
+        $date = new \DateTime('2024-01-01');
+        $result = $this->api->get_form_subscriptions(
+            form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+            created_after: $date
+        );
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
+
+        // Check the correct subscribers were returned.
+        $this->assertGreaterThanOrEqual($date->format('Y-m-d'), date('Y-m-d', strtotime($result->subscribers[0]->created_at)));
+    }
+
+    /**
+     * Test that get_form_subscriptions() returns the expected data
+     * when a valid Form ID is specified and the created_before parameter
+     * is used.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetFormSubscriptionsWithCreatedBeforeParam()
+    {
+        $date = new \DateTime('2024-01-01');
+        $result = $this->api->get_form_subscriptions(
+            form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+            created_before: $date
+        );
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
+
+        // Check the correct subscribers were returned.
+        $this->assertLessThanOrEqual($date->format('Y-m-d'), date('Y-m-d', strtotime($result->subscribers[0]->created_at)));
+    }
 
     /**
      * Test that get_form_subscriptions() returns the expected data
@@ -503,52 +593,52 @@ class ConvertKitAPITest extends TestCase
             per_page: 1
         );
 
-        // Assert a single subscriber was returned.
-        $result = get_object_vars($result);
-        $this->assertArrayHasKey('subscribers', $result);
-        $this->assertIsArray($result['subscribers']);
-        $this->assertCount(1, $result['subscribers']);
-        
-        // Assert pagination exists.
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
         $this->assertPaginationExists($result);
-        $this->assertFalse($result['pagination']->has_previous_page);
-        $this->assertTrue($result['pagination']->has_next_page);
+
+        // Assert a single subscriber was returned.
+        $this->assertCount(1, $result->subscribers);
+        
+        // Assert has_previous_page and has_next_page are correct.
+        $this->assertFalse($result->pagination->has_previous_page);
+        $this->assertTrue($result->pagination->has_next_page);
         
         // Use pagination to fetch next page.
         $result = $this->api->get_form_subscriptions(
             form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
             per_page: 1,
-            after_cursor: $result['pagination']->end_cursor
+            after_cursor: $result->pagination->end_cursor
         );
 
-        // Assert a single subscriber was returned.
-        $result = get_object_vars($result);
-        $this->assertArrayHasKey('subscribers', $result);
-        $this->assertIsArray($result['subscribers']);
-        $this->assertCount(1, $result['subscribers']);
-        
-        // Assert pagination exists.
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
         $this->assertPaginationExists($result);
-        $this->assertTrue($result['pagination']->has_previous_page);
-        $this->assertTrue($result['pagination']->has_next_page);
+
+        // Assert a single subscriber was returned.
+        $this->assertCount(1, $result->subscribers);
+        
+        // Assert has_previous_page and has_next_page are correct.
+        $this->assertTrue($result->pagination->has_previous_page);
+        $this->assertTrue($result->pagination->has_next_page);
 
         // Use pagination to fetch previous page.
         $result = $this->api->get_form_subscriptions(
             form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
             per_page: 1,
-            before_cursor: $result['pagination']->start_cursor
+            before_cursor: $result->pagination->start_cursor
         );
 
-        // Assert a single subscriber was returned.
-        $result = get_object_vars($result);
-        $this->assertArrayHasKey('subscribers', $result);
-        $this->assertIsArray($result['subscribers']);
-        $this->assertCount(1, $result['subscribers']);
-        
-        // Assert pagination exists.
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
         $this->assertPaginationExists($result);
-        $this->assertFalse($result['pagination']->has_previous_page);
-        $this->assertTrue($result['pagination']->has_next_page);
+
+        // Assert a single subscriber was returned.
+        $this->assertCount(1, $result->subscribers);
+        
+        // Assert has_previous_page and has_next_page are correct.
+        $this->assertFalse($result->pagination->has_previous_page);
+        $this->assertTrue($result->pagination->has_next_page);
     }
 
     /**
@@ -2657,6 +2747,21 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Helper method to assert the given key exists as an array
+     * in the API response.
+     * 
+     * @since   2.0.0
+     * 
+     * @param   array   $result     API Result.
+     */
+    private function assertDataExists($result, $key)
+    {
+        $result = get_object_vars($result);
+        $this->assertArrayHasKey($key, $result);
+        $this->assertIsArray($result[$key]);
+    }
+
+    /**
      * Helper method to assert pagination object exists in response.
      * 
      * @since   2.0.0
@@ -2665,6 +2770,7 @@ class ConvertKitAPITest extends TestCase
      */
     private function assertPaginationExists($result)
     {
+        $result = get_object_vars($result);
         $this->assertArrayHasKey('pagination', $result);
         $pagination = get_object_vars($result['pagination']);
         $this->assertArrayHasKey('has_previous_page', $pagination);

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -1581,20 +1581,14 @@ class ConvertKitAPITest extends TestCase
      */
     public function testAddSubscriberToForm()
     {
-        $this->markTestIncomplete();
-
-        $email = $this->generateEmailAddress();
         $result = $this->api->add_subscriber_to_form(
             form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
-            email: $email
+            email: $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
         );
         $this->assertInstanceOf('stdClass', $result);
-        $this->assertArrayHasKey('subscription', get_object_vars($result));
-        $this->assertArrayHasKey('id', get_object_vars($result->subscription));
-        $this->assertEquals(get_object_vars($result->subscription)['subscribable_id'], $_ENV['CONVERTKIT_API_FORM_ID']);
-
-        // Unsubscribe.
-        $this->api->unsubscribe($email);
+        $this->assertArrayHasKey('subscriber', get_object_vars($result));
+        $this->assertArrayHasKey('id', get_object_vars($result->subscriber));
+        $this->assertEquals(get_object_vars($result->subscriber)['id'], $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
     }
 
     /**
@@ -1607,8 +1601,6 @@ class ConvertKitAPITest extends TestCase
      */
     public function testAddSubscriberToFormWithInvalidFormID()
     {
-        $this->markTestIncomplete();
-
         $this->expectException(ClientException::class);
         $result = $this->api->add_subscriber_to_form(
             form_id: 12345,
@@ -1626,8 +1618,6 @@ class ConvertKitAPITest extends TestCase
      */
     public function testAddSubscriberToFormWithInvalidEmailAddress()
     {
-        $this->markTestIncomplete();
-
         $this->expectException(ClientException::class);
         $result = $this->api->add_subscriber_to_form(
             form_id: $_ENV['CONVERTKIT_API_FORM_ID'],
@@ -1636,92 +1626,56 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
-     * Test that add_subscriber_to_form() returns the expected data
-     * when a first_name parameter is included.
+     * Test that add_subscriber_to_form_by_subscriber_id() returns the expected data.
      *
-     * @since   1.0.0
+     * @since   2.0.0
      *
      * @return void
      */
-    public function testAddSubscriberToFormWithFirstName()
+    public function testAddSubscriberToFormByID()
     {
-        $this->markTestIncomplete();
-
-        $emailAddress = $this->generateEmailAddress();
-        $firstName = 'First Name';
-        $result = $this->api->add_subscriber_to_form(
-            form_id: $_ENV['CONVERTKIT_API_FORM_ID'],
-            email: $emailAddress,
-            first_name: $firstName
+        $result = $this->api->add_subscriber_to_form_by_subscriber_id(
+            form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+            subscriber_id: $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
         );
-
         $this->assertInstanceOf('stdClass', $result);
-        $this->assertArrayHasKey('subscription', get_object_vars($result));
-
-        // Fetch subscriber from API to confirm the first name was saved.
-        $subscriber = $this->api->get_subscriber($result->subscription->subscriber->id);
-        $this->assertEquals($subscriber->subscriber->email_address, $emailAddress);
-        $this->assertEquals($subscriber->subscriber->first_name, $firstName);
+        $this->assertArrayHasKey('subscriber', get_object_vars($result));
+        $this->assertArrayHasKey('id', get_object_vars($result->subscriber));
+        $this->assertEquals(get_object_vars($result->subscriber)['id'], $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
     }
 
     /**
-     * Test that add_subscriber_to_form() returns the expected data
-     * when custom field data is included.
+     * Test that add_subscriber_to_form_by_subscriber_id() throws a ClientException when an invalid
+     * form ID is specified.
      *
-     * @since   1.0.0
+     * @since   2.0.0
      *
      * @return void
      */
-    public function testAddSubscriberToFormWithCustomFields()
+    public function testAddSubscriberToFormByIDWithInvalidFormID()
     {
-        $this->markTestIncomplete();
-
-        $result = $this->api->add_subscriber_to_form(
-            form_id: $_ENV['CONVERTKIT_API_FORM_ID'],
-            email: $this->generateEmailAddress(),
-            first_name: 'First Name',
-            fields: [
-                'last_name' => 'Last Name',
-            ]
+        $this->expectException(ClientException::class);
+        $result = $this->api->add_subscriber_to_form_by_subscriber_id(
+            form_id: 12345,
+            subscriber_id: $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
         );
-
-        // Check subscription object returned.
-        $this->assertInstanceOf('stdClass', $result);
-        $this->assertArrayHasKey('subscription', get_object_vars($result));
-
-        // Fetch subscriber from API to confirm the custom fields were saved.
-        $subscriber = $this->api->get_subscriber($result->subscription->subscriber->id);
-        $this->assertEquals($subscriber->subscriber->fields->last_name, 'Last Name');
     }
 
     /**
-     * Test that add_subscriber_to_form() returns the expected data
-     * when custom field data is included.
+     * Test that add_subscriber_to_form_by_subscriber_id() throws a ClientException when an invalid
+     * email address is specified.
      *
-     * @since   1.0.0
+     * @since   2.0.0
      *
      * @return void
      */
-    public function testAddSubscriberToFormWithTagID()
+    public function testAddSubscriberToFormByIDWithInvalidSubscriberID()
     {
-        $this->markTestIncomplete();
-
-        $result = $this->api->add_subscriber_to_form(
+        $this->expectException(ClientException::class);
+        $result = $this->api->add_subscriber_to_form_by_subscriber_id(
             form_id: $_ENV['CONVERTKIT_API_FORM_ID'],
-            email: $this->generateEmailAddress(),
-            first_name: 'First Name',
-            tag_ids: [
-                (int) $_ENV['CONVERTKIT_API_TAG_ID']
-            ]
+            subscriber_id: 12345
         );
-
-        // Check subscription object returned.
-        $this->assertInstanceOf('stdClass', $result);
-        $this->assertArrayHasKey('subscription', get_object_vars($result));
-
-        // Fetch subscriber tags from API to confirm the tag saved.
-        $subscriberTags = $this->api->get_subscriber_tags($result->subscription->subscriber->id);
-        $this->assertEquals($subscriberTags->tags[0]->id, $_ENV['CONVERTKIT_API_TAG_ID']);
     }
 
     /**

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -499,7 +499,10 @@ class ConvertKitAPITest extends TestCase
         $this->assertPaginationExists($result);
 
         // Check the correct subscribers were returned.
-        $this->assertGreaterThanOrEqual($date->format('Y-m-d'), date('Y-m-d', strtotime($result->subscribers[0]->added_at)));
+        $this->assertGreaterThanOrEqual(
+            $date->format('Y-m-d'),
+            date('Y-m-d', strtotime($result->subscribers[0]->added_at))
+        );
     }
 
     /**
@@ -524,7 +527,10 @@ class ConvertKitAPITest extends TestCase
         $this->assertPaginationExists($result);
 
         // Check the correct subscribers were returned.
-        $this->assertLessThanOrEqual($date->format('Y-m-d'), date('Y-m-d', strtotime($result->subscribers[0]->added_at)));
+        $this->assertLessThanOrEqual(
+            $date->format('Y-m-d'),
+            date('Y-m-d', strtotime($result->subscribers[0]->added_at))
+        );
     }
 
     /**
@@ -549,7 +555,10 @@ class ConvertKitAPITest extends TestCase
         $this->assertPaginationExists($result);
 
         // Check the correct subscribers were returned.
-        $this->assertGreaterThanOrEqual($date->format('Y-m-d'), date('Y-m-d', strtotime($result->subscribers[0]->created_at)));
+        $this->assertGreaterThanOrEqual(
+            $date->format('Y-m-d'),
+            date('Y-m-d', strtotime($result->subscribers[0]->created_at))
+        );
     }
 
     /**
@@ -574,7 +583,10 @@ class ConvertKitAPITest extends TestCase
         $this->assertPaginationExists($result);
 
         // Check the correct subscribers were returned.
-        $this->assertLessThanOrEqual($date->format('Y-m-d'), date('Y-m-d', strtotime($result->subscribers[0]->created_at)));
+        $this->assertLessThanOrEqual(
+            $date->format('Y-m-d'),
+            date('Y-m-d', strtotime($result->subscribers[0]->created_at))
+        );
     }
 
     /**
@@ -599,11 +611,11 @@ class ConvertKitAPITest extends TestCase
 
         // Assert a single subscriber was returned.
         $this->assertCount(1, $result->subscribers);
-        
+
         // Assert has_previous_page and has_next_page are correct.
         $this->assertFalse($result->pagination->has_previous_page);
         $this->assertTrue($result->pagination->has_next_page);
-        
+
         // Use pagination to fetch next page.
         $result = $this->api->get_form_subscriptions(
             form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
@@ -617,7 +629,7 @@ class ConvertKitAPITest extends TestCase
 
         // Assert a single subscriber was returned.
         $this->assertCount(1, $result->subscribers);
-        
+
         // Assert has_previous_page and has_next_page are correct.
         $this->assertTrue($result->pagination->has_previous_page);
         $this->assertTrue($result->pagination->has_next_page);
@@ -635,15 +647,15 @@ class ConvertKitAPITest extends TestCase
 
         // Assert a single subscriber was returned.
         $this->assertCount(1, $result->subscribers);
-        
+
         // Assert has_previous_page and has_next_page are correct.
         $this->assertFalse($result->pagination->has_previous_page);
         $this->assertTrue($result->pagination->has_next_page);
     }
 
     /**
-     * Test that get_form_subscriptions() returns the expected data
-     * when a valid Form ID is specified.
+     * Test that get_form_subscriptions() throws a ClientException when an invalid
+     * Form ID is specified.
      *
      * @since   1.0.0
      *
@@ -651,10 +663,44 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetFormSubscriptionsWithInvalidFormID()
     {
-        $this->markTestIncomplete();
-
         $this->expectException(ClientException::class);
-        $result = $this->api->get_form_subscriptions(12345);
+        $result = $this->api->get_form_subscriptions(
+            form_id: 12345
+        );
+    }
+
+    /**
+     * Test that get_form_subscriptions() throws a ClientException when an invalid
+     * subscriber state is specified.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetFormSubscriptionsWithInvalidSubscriberState()
+    {
+        $this->expectException(ClientException::class);
+        $result = $this->api->get_form_subscriptions(
+            form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+            subscriber_state: 'not-a-valid-state'
+        );
+    }
+
+    /**
+     * Test that get_form_subscriptions() throws a ClientException when invalid
+     * pagination parameters are specified.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetFormSubscriptionsWithInvalidPagination()
+    {
+        $this->expectException(ClientException::class);
+        $result = $this->api->get_form_subscriptions(
+            form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+            after_cursor: 'not-a-valid-cursor'
+        );
     }
 
     /**
@@ -2749,9 +2795,9 @@ class ConvertKitAPITest extends TestCase
     /**
      * Helper method to assert the given key exists as an array
      * in the API response.
-     * 
+     *
      * @since   2.0.0
-     * 
+     *
      * @param   array   $result     API Result.
      */
     private function assertDataExists($result, $key)
@@ -2763,9 +2809,9 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Helper method to assert pagination object exists in response.
-     * 
+     *
      * @since   2.0.0
-     * 
+     *
      * @param   array   $result     API Result.
      */
     private function assertPaginationExists($result)


### PR DESCRIPTION
## Summary

Adds support for endpoints in the forms section of the v4 API.

## Testing

- `testGetFormSubscriptionsWithBouncedSubscriberState`: Test that get_form_subscriptions() returns the expected data when a valid Form ID is specified and the subscription status is cancelled.
- `testGetFormSubscriptionsWithAddedAfterParam`: Test that get_form_subscriptions() returns the expected data when a valid Form ID is specified and the added_after parameter is used.
- `testGetFormSubscriptionsWithAddedBeforeParam`: Test that get_form_subscriptions() returns the expected data when a valid Form ID is specified and the added_before parameter is used.
- `testGetFormSubscriptionsWithCreatedAfterParam`: Test that get_form_subscriptions() returns the expected data when a valid Form ID is specified and the created_after parameter is used.
- `testGetFormSubscriptionsWithCreatedBeforeParam`: Test that get_form_subscriptions() returns the expected data when a valid Form ID is specified and the created_before parameter is used.
- `testGetFormSubscriptionsPagination`: Test that get_form_subscriptions() returns the expected data when a valid Form ID is specified and pagination parameters and per_page limits are specified.
- `testGetFormSubscriptionsWithInvalidFormID`: Test that get_form_subscriptions() throws a ClientException when an invalid Form ID is specified.
- `testGetFormSubscriptionsWithInvalidSubscriberState`: Test that get_form_subscriptions() throws a ClientException when an invalid subscriber state is specified.
- `testGetFormSubscriptionsWithInvalidPagination`: Test that get_form_subscriptions() throws a ClientException when invalid pagination parameters are specified.
- `testAddSubscriberToFormByID`: Test that add_subscriber_to_form_by_subscriber_id() returns the expected data.
- `testAddSubscriberToFormByIDWithInvalidFormID`: Test that add_subscriber_to_form_by_subscriber_id() throws a ClientException when an invalid form ID is specified.
- `testAddSubscriberToFormByIDWithInvalidSubscriberID`: Test that add_subscriber_to_form_by_subscriber_id() throws a ClientException when an invalid email address is specified.

Removed Tests:

- `testAddSubscriberToFormWithFirstName`
- `testAddSubscriberToFormWithCustomFields`
- `testAddSubscriberToFormWithTagID`

v4 API has no concept of adding a new subscriber to a form with data; a separate PR will be added to add support for the new `Create a subscriber` endpoint (https://developers.convertkit.com/v4.html#create-a-subscriber), which supports this.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)