### PR TITLE
v4 API: Sequences

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -430,14 +430,14 @@ class ConvertKit_API
     }
 
     /**
-     * Gets all sequences
+     * Gets sequences
      *
-     * @see https://developers.convertkit.com/#list-sequences
+     * @param string  $after_cursor  Return results after the given pagination cursor.
+     * @param string  $before_cursor Return results before the given pagination cursor.
+     * @param integer $per_page      Number of results to return.
      *
-     * @param string    $after_cursor     Return results after the given pagination cursor.
-     * @param string    $before_cursor    Return results before the given pagination cursor.
-     * @param integer   $per_page         Number of results to return.
-     * 
+     * @see https://developers.convertkit.com/v4.html#list-sequences
+     *
      * @return false|mixed
      */
     public function get_sequences(string $after_cursor = '', string $before_cursor = '', int $per_page = 100)
@@ -455,16 +455,17 @@ class ConvertKit_API
     /**
      * Adds a subscriber to a sequence by email address
      *
-     * @param integer               $sequence_id Sequence ID.
-     * @param string                $email       Email Address.
+     * @param integer $sequence_id Sequence ID.
+     * @param string  $email       Email Address.
      *
      * @see https://developers.convertkit.com/v4.html#add-subscriber-to-sequence-by-email-address
      *
      * @return false|mixed
      */
-    public function add_subscriber_to_sequence(int $sequence_id, string $email) {
+    public function add_subscriber_to_sequence(int $sequence_id, string $email)
+    {
         return $this->post(
-            endpoint: sprintf('sequences/%s/subscribers', $sequence),
+            endpoint: sprintf('sequences/%s/subscribers', $sequence_id),
             args: ['email_address' => $email]
         );
     }

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -1562,7 +1562,7 @@ class ConvertKit_API
      * @return array<string, string|integer>
      */
     private function build_pagination_params(
-        array $params,
+        array $params = [],
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -408,11 +408,22 @@ class ConvertKit_API
      *
      * @see https://developers.convertkit.com/#list-sequences
      *
+     * @param string    $after_cursor     Return results after the given pagination cursor.
+     * @param string    $before_cursor    Return results before the given pagination cursor.
+     * @param integer   $per_page         Number of results to return.
+     * 
      * @return false|mixed
      */
-    public function get_sequences()
+    public function get_sequences(string $after_cursor = '', string $before_cursor = '', int $per_page = 100)
     {
-        return $this->get('sequences');
+        return $this->get(
+            endpoint: 'sequences',
+            args: $this->build_pagination_params(
+                after_cursor: $after_cursor,
+                before_cursor: $before_cursor,
+                per_page: $per_page
+            )
+        );
     }
 
     /**
@@ -1510,6 +1521,37 @@ class ConvertKit_API
         $markup = str_replace('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', '', $markup);
 
         return $markup;
+    }
+
+    /**
+     * Adds pagination parameters to the given array of existing API parameters.
+     *
+     * @param array<string, string|integer> $params        API parameters.
+     * @param string                        $after_cursor  Return results after the given pagination cursor.
+     * @param string                        $before_cursor Return results before the given pagination cursor.
+     * @param integer                       $per_page      Number of results to return.
+     *
+     * @since 2.0.0
+     *
+     * @return array<string, string|integer>
+     */
+    private function build_pagination_params(
+        array $params = [],
+        string $after_cursor = '',
+        string $before_cursor = '',
+        int $per_page = 100
+    ) {
+        if (!empty($after_cursor)) {
+            $params['after'] = $after_cursor;
+        }
+        if (!empty($before_cursor)) {
+            $params['before'] = $before_cursor;
+        }
+        if (!empty($per_page)) {
+            $params['per_page'] = $per_page;
+        }
+
+        return $params;
     }
 
     /**

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -639,19 +639,21 @@ class ConvertKitAPITest extends TestCase
      */
     public function testGetSequences()
     {
-        $this->markTestIncomplete();
-
         $result = $this->api->get_sequences();
-        $this->assertInstanceOf('stdClass', $result);
+
+        // Assert sequences and pagination exist.
+        $this->assertDataExists($result, 'sequences');
+        $this->assertPaginationExists($result);
 
         // Check first sequence in resultset has expected data.
-        $sequence = get_object_vars($result->courses[0]);
+        $sequence = get_object_vars($result->sequences[0]);
         $this->assertArrayHasKey('id', $sequence);
         $this->assertArrayHasKey('name', $sequence);
         $this->assertArrayHasKey('hold', $sequence);
         $this->assertArrayHasKey('repeat', $sequence);
         $this->assertArrayHasKey('created_at', $sequence);
     }
+
 
     /**
      * Test that add_subscriber_to_sequence() returns the expected data.


### PR DESCRIPTION
## Summary

Adds support for endpoints in the sequences section of the v4 API.

## Testing

- `testGetSequencesPagination`: Test that get_sequences() returns the expected data when pagination parameters and per_page limits are specified.
- `testGetSequenceSubscriptionsWithBouncedSubscriberState`: Test that get_sequence_subscriptions() returns the expected data when a valid Sequence ID is specified and the subscription status is cancelled.
- `testGetSequenceSubscriptionsWithAddedAfterParam`: Test that get_sequence_subscriptions() returns the expected data when a valid Sequence ID is specified and the added_after parameter is used.
- `testGetSequenceSubscriptionsWithAddedBeforeParam`: Test that get_sequence_subscriptions() returns the expected data when a valid Sequence ID is specified and the added_before parameter is used.
- `testGetSequenceSubscriptionsWithCreatedAfterParam`: Test that get_sequence_subscriptions() returns the expected data when a valid Sequence ID is specified and the created_after parameter is used.
- `testGetSequenceSubscriptionsWithCreatedBeforeParam`: Test that get_sequence_subscriptions() returns the expected data when a valid Sequence ID is specified and the created_before parameter is used.
- `testGetSequenceSubscriptionsPagination`: Test that get_sequence_subscriptions() returns the expected data when a valid Sequence ID is specified and pagination parameters and per_page limits are specified.
- `testGetSequenceSubscriptionsWithInvalidSequenceID`: Test that get_sequence_subscriptions() throws a ClientException when an invalid Sequence ID is specified.
- `testGetSequenceSubscriptionsWithInvalidSubscriberState`: Test that get_sequence_subscriptions() throws a ClientException when an invalid subscriber state is specified.
- `testGetSequenceSubscriptionsWithInvalidPagination`: Test that get_sequence_subscriptions() throws a ClientException when invalid pagination parameters are specified.
- `testAddSubscriberToSequenceByID`: Test that add_subscriber_to_sequence_by_subscriber_id() returns the expected data.
- `testAddSubscriberToSequenceByIDWithInvalidSequenceID`: Test that add_subscriber_to_sequence_by_subscriber_id() throws a ClientException when an invalid Sequence ID is specified.
- `testAddSubscriberToSequenceByIDWithInvalidSubscriberID`: Test that add_subscriber_to_sequence_by_subscriber_id() throws a ClientException when an invalid email address is specified.

Removed Tests:

- `testAddSubscriberToSequenceWithFirstName`
- `testAddSubscriberToSequenceWithCustomFields`
- `testAddSubscriberToSequenceWithTagID`

v4 API has no concept of adding a new subscriber to a sequence with data; a separate PR will be added to add support for the new `Create a subscriber` endpoint (https://developers.convertkit.com/v4.html#create-a-subscriber), which supports this.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)