### PR TITLE
v4 API: Expose `Response` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,26 @@ $api = new \ConvertKit_API\ConvertKit_API(
 );
 ```
 
+API requests may then be performed:
+
+```php
+$result = $api->add_subscriber_to_form(12345, 'joe.bloggs@convertkit.com');
+```
+
+To determine whether a new entity / relationship was created, or an existing entity / relationship updated, inspect the HTTP code of the last request:
+
+```php
+$result = $api->add_subscriber_to_form(12345, 'joe.bloggs@convertkit.com');
+$code = $api->getResponseInterface()->getStatusCode(); // 200 OK if e.g. a subscriber already added to the specified form, 201 Created if the subscriber added to the specified form for the first time.
+```
+
+The PSR-7 response can be fetched and further inspected, if required - for example, to check if a header exists:
+
+```php
+$result = $api->add_subscriber_to_form(12345, 'joe.bloggs@convertkit.com');
+$api->getResponseInterface()->hasHeader('Content-Length'); // Check if the last API request included a `Content-Length` header
+```
+
 ### 1.x (v3 API, API Key and Secret, PHP 7.4+)
 
 Get your ConvertKit API Key and API Secret [here](https://app.convertkit.com/account/edit) and set it somewhere in your application.

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -95,6 +95,20 @@ class ConvertKit_API
      */
     protected $client;
 
+    /**
+     * Guzzle Http Response
+     *
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    protected $response;
+
+    /**
+     * Guzzle Http Status Code
+     *
+     * @var integer
+     */
+    protected $status_code = 0;
+
 
     /**
      * Constructor for ConvertKitAPI instance
@@ -1636,21 +1650,45 @@ class ConvertKit_API
         }
 
         // Send request.
-        $response = $this->client->send(
+        $this->response = $this->client->send(
             $request,
             ['exceptions' => false]
         );
 
         // Inspect response.
-        $status_code   = $response->getStatusCode();
-        $response_body = $response->getBody()->getContents();
+        $this->status_code = $this->response->getStatusCode();
+        $response_body     = $this->response->getBody()->getContents();
 
         // Log response.
-        $this->create_log(sprintf('Response Status Code: %s', $response->getStatusCode()));
-        $this->create_log(sprintf('Response Body: %s', $response->getBody()->getContents()));
+        $this->create_log(sprintf('Response Status Code: %s', $this->response->getStatusCode()));
+        $this->create_log(sprintf('Response Body: %s', $this->response->getBody()->getContents()));
         $this->create_log('Finish request successfully');
 
         // Return response.
         return json_decode($response_body);
+    }
+
+    /**
+     * Returns the response interface used for the last API request.
+     *
+     * @since 2.0.0
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function get_response_interface()
+    {
+        return $this->response;
+    }
+
+    /**
+     * Returns the HTTP status code for the last successful API request.
+     *
+     * @since 2.0.0
+     *
+     * @return integer
+     */
+    public function get_response_status_code()
+    {
+        return $this->status_code;
     }
 }

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -102,13 +102,6 @@ class ConvertKit_API
      */
     protected $response;
 
-    /**
-     * Guzzle Http Status Code
-     *
-     * @var integer
-     */
-    protected $status_code = 0;
-
 
     /**
      * Constructor for ConvertKitAPI instance
@@ -1655,13 +1648,12 @@ class ConvertKit_API
             ['exceptions' => false]
         );
 
-        // Inspect response.
-        $this->status_code = $this->response->getStatusCode();
-        $response_body     = $this->response->getBody()->getContents();
+        // Get response.
+        $response_body = $this->response->getBody()->getContents();
 
         // Log response.
         $this->create_log(sprintf('Response Status Code: %s', $this->response->getStatusCode()));
-        $this->create_log(sprintf('Response Body: %s', $this->response->getBody()->getContents()));
+        $this->create_log(sprintf('Response Body: %s', $response_body));
         $this->create_log('Finish request successfully');
 
         // Return response.
@@ -1675,20 +1667,8 @@ class ConvertKit_API
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    public function get_response_interface()
+    public function getResponseInterface()
     {
         return $this->response;
-    }
-
-    /**
-     * Returns the HTTP status code for the last successful API request.
-     *
-     * @since 2.0.0
-     *
-     * @return integer
-     */
-    public function get_response_status_code()
-    {
-        return $this->status_code;
     }
 }

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -62,6 +62,29 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that a Response instance is returned when calling getResponseInterface()
+     * after making an API request.
+     *
+     * @since   2.0.0
+     *
+     * @return  void
+     */
+    public function testGetResponseInterface()
+    {
+        // Assert response interface is null, as no API request made.
+        $this->assertNull($this->api->getResponseInterface());
+
+        // Perform an API request.
+        $result = $this->api->get_account();
+
+        // Assert response interface is of a valid type.
+        $this->assertInstanceOf(Response::class, $this->api->getResponseInterface());
+
+        // Assert the correct status code was returned.
+        $this->assertEquals(200, $this->api->getResponseInterface()->getStatusCode());
+    }
+
+    /**
      * Test that a ClientInterface can be injected.
      *
      * @since   1.3.0
@@ -95,6 +118,12 @@ class ConvertKitAPITest extends TestCase
         $this->assertSame('Test Account for Guzzle Mock', $result->name);
         $this->assertSame('free', $result->plan_type);
         $this->assertSame('mock@guzzle.mock', $result->primary_email_address);
+
+        // Assert response interface is of a valid type when using `set_http_client`.
+        $this->assertInstanceOf(Response::class, $this->api->getResponseInterface());
+
+        // Assert the correct status code was returned.
+        $this->assertEquals(200, $this->api->getResponseInterface()->getStatusCode());
     }
 
     /**
@@ -221,29 +250,6 @@ class ConvertKitAPITest extends TestCase
     {
         $result = $this->api->get_account();
         $this->assertEmpty($this->getLogFileContents());
-    }
-
-    /**
-     * Test that a Response instance is returned when calling getResponseInterface()
-     * after making an API request.
-     *
-     * @since   2.0.0
-     *
-     * @return  void
-     */
-    public function testGetResponseInterface()
-    {
-        // Assert response interface is null, as no API request made.
-        $this->assertNull($this->api->getResponseInterface());
-
-        // Perform an API request.
-        $result = $this->api->get_account();
-
-        // Assert response interface is of a valid type.
-        $this->assertInstanceOf(Response::class, $this->api->getResponseInterface());
-
-        // Assert the correct status code was returned.
-        $this->assertEquals(200, $this->api->getResponseInterface()->getStatusCode());
     }
 
     /**

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -224,7 +224,7 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
-     * Test that a Response instance is returned when calling get_response_interface()
+     * Test that a Response instance is returned when calling getResponseInterface()
      * after making an API request.
      *
      * @since   2.0.0
@@ -234,32 +234,16 @@ class ConvertKitAPITest extends TestCase
     public function testGetResponseInterface()
     {
         // Assert response interface is null, as no API request made.
-        $this->assertNull($this->api->get_response_interface());
+        $this->assertNull($this->api->getResponseInterface());
 
         // Perform an API request.
         $result = $this->api->get_account();
 
         // Assert response interface is of a valid type.
-        $this->assertInstanceOf(Response::class, $this->api->get_response_interface());
-    }
+        $this->assertInstanceOf(Response::class, $this->api->getResponseInterface());
 
-    /**
-     * Test that the get_response_status_code() returns the expected HTTP status code.
-     *
-     * @since   2.0.0
-     *
-     * @return  void
-     */
-    public function testGetResponseStatusCode()
-    {
-        // Assert no status code has yet been set in get_response_status_code, as no API request made.
-        $this->assertEquals(0, $this->api->get_response_status_code());
-
-        // Perform an API request.
-        $result = $this->api->get_account();
-
-        // Assert the correct status code defined in get_response_status_code()
-        $this->assertEquals(200, $this->api->get_response_status_code());
+        // Assert the correct status code was returned.
+        $this->assertEquals(200, $this->api->getResponseInterface()->getStatusCode());
     }
 
     /**

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -224,6 +224,45 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that a Response instance is returned when calling get_response_interface()
+     * after making an API request.
+     *
+     * @since   2.0.0
+     *
+     * @return  void
+     */
+    public function testGetResponseInterface()
+    {
+        // Assert response interface is null, as no API request made.
+        $this->assertNull($this->api->get_response_interface());
+
+        // Perform an API request.
+        $result = $this->api->get_account();
+
+        // Assert response interface is of a valid type.
+        $this->assertInstanceOf(Response::class, $this->api->get_response_interface());
+    }
+
+    /**
+     * Test that the get_response_status_code() returns the expected HTTP status code.
+     *
+     * @since   2.0.0
+     *
+     * @return  void
+     */
+    public function testGetResponseStatusCode()
+    {
+        // Assert no status code has yet been set in get_response_status_code, as no API request made.
+        $this->assertEquals(0, $this->api->get_response_status_code());
+
+        // Perform an API request.
+        $result = $this->api->get_account();
+
+        // Assert the correct status code defined in get_response_status_code()
+        $this->assertEquals(200, $this->api->get_response_status_code());
+    }
+
+    /**
      * Test that get_oauth_url() returns the correct URL to begin the OAuth process.
      *
      * @since   2.0.0


### PR DESCRIPTION
## Summary

Exposes the `GuzzleHttp\Psr7\Response` object via using `getResponseInterface()`, allowing the consumer to check e.g. a 2xx HTTP status code, header or other properties:

```php
$result = $api->add_subscriber_to_form(12345, 'joe.bloggs@convertkit.com');
$code = $api->getResponseInterface()->getStatusCode(); // 200 OK if e.g. a subscriber already added to the specified form, 201 Created if the subscriber added to the specified form for the first time.
```

## Testing

- `testGetResponseInterface`: Test that a valid PSR-7 response object is returned by `getResponseInterface` and can be interacted with.
- `testClientInterfaceInjection`: Test that a valid PSR-7 response object is returned by `getResponseInterface` when `set_http_client` is used ([PR](https://github.com/ConvertKit/ConvertKitSDK-PHP/pull/68)).

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)