### PR TITLE
v4 API: Cleanup after Tests

### DIFF
--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -35,18 +35,18 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Custom Field IDs to delete on teardown of a test.
-     * 
+     *
      * @since   2.0.0
-     * 
+     *
      * @var     array<int, int>
      */
     protected $custom_field_ids = [];
 
     /**
      * Subscriber IDs to unsubscribe on teardown of a test.
-     * 
+     *
      * @since   2.0.0
-     * 
+     *
      * @var     array<int, int>
      */
     protected $subscriber_ids = [];
@@ -89,12 +89,12 @@ class ConvertKitAPITest extends TestCase
     protected function tearDown(): void
     {
         // Delete any Custom Fields.
-        foreach($this->custom_field_ids as $id) {
+        foreach ($this->custom_field_ids as $id) {
             $this->api->delete_custom_field($id);
         }
 
         // Unsubscribe any Subscribers.
-        foreach($this->subscriber_ids as $id) {
+        foreach ($this->subscriber_ids as $id) {
             $this->api->unsubscribe_by_id($id);
         }
     }
@@ -2725,7 +2725,7 @@ class ConvertKitAPITest extends TestCase
         $this->subscriber_ids[] = $result->subscriber->id;
 
         // Assert subscriber exists with correct data.
-        $this->assertEquals($result->subscriber->email_address, $emailAddress); 
+        $this->assertEquals($result->subscriber->email_address, $emailAddress);
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds a `tearDown` method to delete custom field and unsubscribe email addresses after a test passes or fails.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)