### PR TITLE
v4 API: Add support for `include_total_count`

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -496,7 +496,7 @@ class ConvertKit_API
         }
 
         // Build pagination parameters.
-        $options = $this->build_pagination_params(
+        $options = $this->build_total_count_and_pagination_params(
             params: $options,
             after_cursor: $after_cursor,
             before_cursor: $before_cursor,
@@ -525,7 +525,7 @@ class ConvertKit_API
     {
         return $this->get(
             endpoint: 'sequences',
-            args: $this->build_pagination_params(
+            args: $this->build_total_count_and_pagination_params(
                 after_cursor: $after_cursor,
                 before_cursor: $before_cursor,
                 per_page: $per_page
@@ -616,7 +616,7 @@ class ConvertKit_API
         }
 
         // Build pagination parameters.
-        $options = $this->build_pagination_params(
+        $options = $this->build_total_count_and_pagination_params(
             params: $options,
             after_cursor: $after_cursor,
             before_cursor: $before_cursor,
@@ -631,21 +631,27 @@ class ConvertKit_API
     }
 
     /**
-     * Gets tags
+     * List tags.
      *
-     * @param string  $after_cursor  Return results after the given pagination cursor.
-     * @param string  $before_cursor Return results before the given pagination cursor.
-     * @param integer $per_page      Number of results to return.
+     * @param boolean $include_total_count  To include the total count of records in the response, use true.
+     * @param string  $after_cursor         Return results after the given pagination cursor.
+     * @param string  $before_cursor        Return results before the given pagination cursor.
+     * @param integer $per_page             Number of results to return.
      *
      * @see https://developers.convertkit.com/v4.html#list-tags
      *
-     * @return false|mixed
+     * @return false|array<int,\stdClass>
      */
-    public function get_tags(string $after_cursor = '', string $before_cursor = '', int $per_page = 100)
-    {
+    public function get_tags(
+        bool $include_total_count = false,
+        string $after_cursor = '',
+        string $before_cursor = '',
+        int $per_page = 100
+    ) {
         return $this->get(
             endpoint: 'tags',
-            args: $this->build_pagination_params(
+            args: $this->build_total_count_and_pagination_params(
+                include_total_count: $include_total_count,
                 after_cursor: $after_cursor,
                 before_cursor: $before_cursor,
                 per_page: $per_page
@@ -825,7 +831,7 @@ class ConvertKit_API
         }
 
         // Build pagination parameters.
-        $options = $this->build_pagination_params(
+        $options = $this->build_total_count_and_pagination_params(
             params: $options,
             after_cursor: $after_cursor,
             before_cursor: $before_cursor,
@@ -859,21 +865,15 @@ class ConvertKit_API
         string $before_cursor = '',
         int $per_page = 100
     ) {
-        // Build parameters.
-        $options = ['include_total_count' => $include_total_count];
-
-        // Build pagination parameters.
-        $options = $this->build_pagination_params(
-            params: $options,
-            after_cursor: $after_cursor,
-            before_cursor: $before_cursor,
-            per_page: $per_page
-        );
-
         // Send request.
         return $this->get(
             endpoint: 'email_templates',
-            args: $options
+            args: $this->build_total_count_and_pagination_params(
+                include_total_count: $include_total_count,
+                after_cursor: $after_cursor,
+                before_cursor: $before_cursor,
+                per_page: $per_page
+            )
         );
     }
 
@@ -993,19 +993,20 @@ class ConvertKit_API
     }
 
     /**
-     * Get subscribers.
+     * List subscribers.
      *
-     * @param string    $subscriber_state Subscriber State (active|bounced|cancelled|complained|inactive).
-     * @param string    $email_address    Search susbcribers by email address. This is an exact match search.
-     * @param \DateTime $created_after    Filter subscribers who have been created after this date.
-     * @param \DateTime $created_before   Filter subscribers who have been created before this date.
-     * @param \DateTime $updated_after    Filter subscribers who have been updated after this date.
-     * @param \DateTime $updated_before   Filter subscribers who have been updated before this date.
-     * @param string    $sort_field       Sort Field (id|updated_at|cancelled_at).
-     * @param string    $sort_order       Sort Order (asc|desc).
-     * @param string    $after_cursor     Return results after the given pagination cursor.
-     * @param string    $before_cursor    Return results before the given pagination cursor.
-     * @param integer   $per_page         Number of results to return.
+     * @param string    $subscriber_state       Subscriber State (active|bounced|cancelled|complained|inactive).
+     * @param string    $email_address          Search susbcribers by email address. This is an exact match search.
+     * @param \DateTime $created_after          Filter subscribers who have been created after this date.
+     * @param \DateTime $created_before         Filter subscribers who have been created before this date.
+     * @param \DateTime $updated_after          Filter subscribers who have been updated after this date.
+     * @param \DateTime $updated_before         Filter subscribers who have been updated before this date.
+     * @param string    $sort_field             Sort Field (id|updated_at|cancelled_at).
+     * @param string    $sort_order             Sort Order (asc|desc).
+     * @param boolean   $include_total_count    To include the total count of records in the response, use true.
+     * @param string    $after_cursor           Return results after the given pagination cursor.
+     * @param string    $before_cursor          Return results before the given pagination cursor.
+     * @param integer   $per_page               Number of results to return.
      *
      * @since 2.0.0
      *
@@ -1022,6 +1023,7 @@ class ConvertKit_API
         \DateTime $updated_before = null,
         string $sort_field = 'id',
         string $sort_order = 'desc',
+        bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100
@@ -1055,8 +1057,9 @@ class ConvertKit_API
         }
 
         // Build pagination parameters.
-        $options = $this->build_pagination_params(
+        $options = $this->build_total_count_and_pagination_params(
             params: $options,
+            include_total_count: $include_total_count,
             after_cursor: $after_cursor,
             before_cursor: $before_cursor,
             per_page: $per_page
@@ -1257,10 +1260,11 @@ class ConvertKit_API
     /**
      * Get a list of the tags for a subscriber.
      *
-     * @param integer $subscriber_id Subscriber ID.
-     * @param string  $after_cursor  Return results after the given pagination cursor.
-     * @param string  $before_cursor Return results before the given pagination cursor.
-     * @param integer $per_page      Number of results to return.
+     * @param integer $subscriber_id        Subscriber ID.
+     * @param boolean $include_total_count  To include the total count of records in the response, use true.
+     * @param string  $after_cursor         Return results after the given pagination cursor.
+     * @param string  $before_cursor        Return results before the given pagination cursor.
+     * @param integer $per_page             Number of results to return.
      *
      * @see https://developers.convertkit.com/v4.html#list-tags-for-a-subscriber
      *
@@ -1268,13 +1272,15 @@ class ConvertKit_API
      */
     public function get_subscriber_tags(
         int $subscriber_id,
+        bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100
     ) {
         return $this->get(
             endpoint: sprintf('subscribers/%s/tags', $subscriber_id),
-            args: $this->build_pagination_params(
+            args: $this->build_total_count_and_pagination_params(
+                include_total_count: $include_total_count,
                 after_cursor: $after_cursor,
                 before_cursor: $before_cursor,
                 per_page: $per_page
@@ -1588,21 +1594,15 @@ class ConvertKit_API
         string $before_cursor = '',
         int $per_page = 100
     ) {
-        // Build parameters.
-        $options = ['include_total_count' => $include_total_count];
-
-        // Build pagination parameters.
-        $options = $this->build_pagination_params(
-            params: $options,
-            after_cursor: $after_cursor,
-            before_cursor: $before_cursor,
-            per_page: $per_page
-        );
-
         // Send request.
         return $this->get(
             endpoint: 'custom_fields',
-            args: $options
+            args: $this->build_total_count_and_pagination_params(
+                include_total_count: $include_total_count,
+                after_cursor: $after_cursor,
+                before_cursor: $before_cursor,
+                per_page: $per_page
+            )
         );
     }
 
@@ -1716,21 +1716,15 @@ class ConvertKit_API
         string $before_cursor = '',
         int $per_page = 100
     ) {
-        // Build parameters.
-        $options = ['include_total_count' => $include_total_count];
-
-        // Build pagination parameters.
-        $options = $this->build_pagination_params(
-            params: $options,
-            after_cursor: $after_cursor,
-            before_cursor: $before_cursor,
-            per_page: $per_page
-        );
-
         // Send request.
         return $this->get(
             endpoint: 'purchases',
-            args: $options
+            args: $this->build_total_count_and_pagination_params(
+                include_total_count: $include_total_count,
+                after_cursor: $after_cursor,
+                before_cursor: $before_cursor,
+                per_page: $per_page
+            )
         );
     }
 
@@ -1818,21 +1812,15 @@ class ConvertKit_API
         string $before_cursor = '',
         int $per_page = 100
     ) {
-        // Build parameters.
-        $options = ['include_total_count' => $include_total_count];
-
-        // Build pagination parameters.
-        $options = $this->build_pagination_params(
-            params: $options,
-            after_cursor: $after_cursor,
-            before_cursor: $before_cursor,
-            per_page: $per_page
-        );
-
         // Send request.
         return $this->get(
             endpoint: 'segments',
-            args: $options
+            args: $this->build_total_count_and_pagination_params(
+                include_total_count: $include_total_count,
+                after_cursor: $after_cursor,
+                before_cursor: $before_cursor,
+                per_page: $per_page
+            )
         );
     }
 
@@ -1975,23 +1963,26 @@ class ConvertKit_API
     }
 
     /**
-     * Adds pagination parameters to the given array of existing API parameters.
+     * Adds total count and pagination parameters to the given array of existing API parameters.
      *
-     * @param array<string, string|integer|bool> $params        API parameters.
-     * @param string                             $after_cursor  Return results after the given pagination cursor.
-     * @param string                             $before_cursor Return results before the given pagination cursor.
-     * @param integer                            $per_page      Number of results to return.
+     * @param array<string, string|integer|bool> $params                API parameters.
+     * @param boolean                            $include_total_count   Return total count of records.
+     * @param string                             $after_cursor          Return results after the given pagination cursor.
+     * @param string                             $before_cursor         Return results before the given pagination cursor.
+     * @param integer                            $per_page              Number of results to return.
      *
      * @since 2.0.0
      *
      * @return array<string, string|integer|bool>
      */
-    private function build_pagination_params(
+    private function build_total_count_and_pagination_params(
         array $params = [],
+        bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100
     ) {
+        $params['include_total_count'] = $include_total_count;
         if (!empty($after_cursor)) {
             $params['after'] = $after_cursor;
         }

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -451,16 +451,16 @@ class ConvertKit_API
     /**
      * List subscribers for a form
      *
-     * @param integer   $form_id                Form ID.
-     * @param string    $subscriber_state       Subscriber State (active|bounced|cancelled|complained|inactive).
-     * @param \DateTime $created_after          Filter subscribers who have been created after this date.
-     * @param \DateTime $created_before         Filter subscribers who have been created before this date.
-     * @param \DateTime $added_after            Filter subscribers who have been added to the form after this date.
-     * @param \DateTime $added_before           Filter subscribers who have been added to the form before this date.
-     * @param boolean   $include_total_count    To include the total count of records in the response, use true.
-     * @param string    $after_cursor           Return results after the given pagination cursor.
-     * @param string    $before_cursor          Return results before the given pagination cursor.
-     * @param integer   $per_page               Number of results to return.
+     * @param integer   $form_id             Form ID.
+     * @param string    $subscriber_state    Subscriber State (active|bounced|cancelled|complained|inactive).
+     * @param \DateTime $created_after       Filter subscribers who have been created after this date.
+     * @param \DateTime $created_before      Filter subscribers who have been created before this date.
+     * @param \DateTime $added_after         Filter subscribers who have been added to the form after this date.
+     * @param \DateTime $added_before        Filter subscribers who have been added to the form before this date.
+     * @param boolean   $include_total_count To include the total count of records in the response, use true.
+     * @param string    $after_cursor        Return results after the given pagination cursor.
+     * @param string    $before_cursor       Return results before the given pagination cursor.
+     * @param integer   $per_page            Number of results to return.
      *
      * @see https://developers.convertkit.com/v4.html#list-subscribers-for-a-form
      *
@@ -513,10 +513,10 @@ class ConvertKit_API
     /**
      * Gets sequences
      *
-     * @param boolean $include_total_count  To include the total count of records in the response, use true.
-     * @param string  $after_cursor  Return results after the given pagination cursor.
-     * @param string  $before_cursor Return results before the given pagination cursor.
-     * @param integer $per_page      Number of results to return.
+     * @param boolean $include_total_count To include the total count of records in the response, use true.
+     * @param string  $after_cursor        Return results after the given pagination cursor.
+     * @param string  $before_cursor       Return results before the given pagination cursor.
+     * @param integer $per_page            Number of results to return.
      *
      * @see https://developers.convertkit.com/v4.html#list-sequences
      *
@@ -577,16 +577,16 @@ class ConvertKit_API
     /**
      * List subscribers for a sequence
      *
-     * @param integer   $sequence_id            Sequence ID.
-     * @param string    $subscriber_state       Subscriber State (active|bounced|cancelled|complained|inactive).
-     * @param \DateTime $created_after          Filter subscribers who have been created after this date.
-     * @param \DateTime $created_before         Filter subscribers who have been created before this date.
-     * @param \DateTime $added_after            Filter subscribers who have been added to the form after this date.
-     * @param \DateTime $added_before           Filter subscribers who have been added to the form before this date.
-     * @param boolean   $include_total_count    To include the total count of records in the response, use true.
-     * @param string    $after_cursor           Return results after the given pagination cursor.
-     * @param string    $before_cursor          Return results before the given pagination cursor.
-     * @param integer   $per_page               Number of results to return.
+     * @param integer   $sequence_id         Sequence ID.
+     * @param string    $subscriber_state    Subscriber State (active|bounced|cancelled|complained|inactive).
+     * @param \DateTime $created_after       Filter subscribers who have been created after this date.
+     * @param \DateTime $created_before      Filter subscribers who have been created before this date.
+     * @param \DateTime $added_after         Filter subscribers who have been added to the form after this date.
+     * @param \DateTime $added_before        Filter subscribers who have been added to the form before this date.
+     * @param boolean   $include_total_count To include the total count of records in the response, use true.
+     * @param string    $after_cursor        Return results after the given pagination cursor.
+     * @param string    $before_cursor       Return results before the given pagination cursor.
+     * @param integer   $per_page            Number of results to return.
      *
      * @see https://developers.convertkit.com/v4.html#list-subscribers-for-a-sequence
      *
@@ -638,10 +638,10 @@ class ConvertKit_API
     /**
      * List tags.
      *
-     * @param boolean $include_total_count  To include the total count of records in the response, use true.
-     * @param string  $after_cursor         Return results after the given pagination cursor.
-     * @param string  $before_cursor        Return results before the given pagination cursor.
-     * @param integer $per_page             Number of results to return.
+     * @param boolean $include_total_count To include the total count of records in the response, use true.
+     * @param string  $after_cursor        Return results after the given pagination cursor.
+     * @param string  $before_cursor       Return results before the given pagination cursor.
+     * @param integer $per_page            Number of results to return.
      *
      * @see https://developers.convertkit.com/v4.html#list-tags
      *
@@ -791,16 +791,16 @@ class ConvertKit_API
     /**
      * List subscribers for a tag
      *
-     * @param integer   $tag_id                 Tag ID.
-     * @param string    $subscriber_state       Subscriber State (active|bounced|cancelled|complained|inactive).
-     * @param \DateTime $created_after          Filter subscribers who have been created after this date.
-     * @param \DateTime $created_before         Filter subscribers who have been created before this date.
-     * @param \DateTime $tagged_after           Filter subscribers who have been tagged after this date.
-     * @param \DateTime $tagged_before          Filter subscribers who have been tagged before this date.
-     * @param boolean   $include_total_count    To include the total count of records in the response, use true.
-     * @param string    $after_cursor           Return results after the given pagination cursor.
-     * @param string    $before_cursor          Return results before the given pagination cursor.
-     * @param integer   $per_page               Number of results to return.
+     * @param integer   $tag_id              Tag ID.
+     * @param string    $subscriber_state    Subscriber State (active|bounced|cancelled|complained|inactive).
+     * @param \DateTime $created_after       Filter subscribers who have been created after this date.
+     * @param \DateTime $created_before      Filter subscribers who have been created before this date.
+     * @param \DateTime $tagged_after        Filter subscribers who have been tagged after this date.
+     * @param \DateTime $tagged_before       Filter subscribers who have been tagged before this date.
+     * @param boolean   $include_total_count To include the total count of records in the response, use true.
+     * @param string    $after_cursor        Return results after the given pagination cursor.
+     * @param string    $before_cursor       Return results before the given pagination cursor.
+     * @param integer   $per_page            Number of results to return.
      *
      * @see https://developers.convertkit.com/v4.html#list-subscribers-for-a-tag
      *
@@ -1000,18 +1000,18 @@ class ConvertKit_API
     /**
      * List subscribers.
      *
-     * @param string    $subscriber_state       Subscriber State (active|bounced|cancelled|complained|inactive).
-     * @param string    $email_address          Search susbcribers by email address. This is an exact match search.
-     * @param \DateTime $created_after          Filter subscribers who have been created after this date.
-     * @param \DateTime $created_before         Filter subscribers who have been created before this date.
-     * @param \DateTime $updated_after          Filter subscribers who have been updated after this date.
-     * @param \DateTime $updated_before         Filter subscribers who have been updated before this date.
-     * @param string    $sort_field             Sort Field (id|updated_at|cancelled_at).
-     * @param string    $sort_order             Sort Order (asc|desc).
-     * @param boolean   $include_total_count    To include the total count of records in the response, use true.
-     * @param string    $after_cursor           Return results after the given pagination cursor.
-     * @param string    $before_cursor          Return results before the given pagination cursor.
-     * @param integer   $per_page               Number of results to return.
+     * @param string    $subscriber_state    Subscriber State (active|bounced|cancelled|complained|inactive).
+     * @param string    $email_address       Search susbcribers by email address. This is an exact match search.
+     * @param \DateTime $created_after       Filter subscribers who have been created after this date.
+     * @param \DateTime $created_before      Filter subscribers who have been created before this date.
+     * @param \DateTime $updated_after       Filter subscribers who have been updated after this date.
+     * @param \DateTime $updated_before      Filter subscribers who have been updated before this date.
+     * @param string    $sort_field          Sort Field (id|updated_at|cancelled_at).
+     * @param string    $sort_order          Sort Order (asc|desc).
+     * @param boolean   $include_total_count To include the total count of records in the response, use true.
+     * @param string    $after_cursor        Return results after the given pagination cursor.
+     * @param string    $before_cursor       Return results before the given pagination cursor.
+     * @param integer   $per_page            Number of results to return.
      *
      * @since 2.0.0
      *
@@ -1262,11 +1262,11 @@ class ConvertKit_API
     /**
      * Get a list of the tags for a subscriber.
      *
-     * @param integer $subscriber_id        Subscriber ID.
-     * @param boolean $include_total_count  To include the total count of records in the response, use true.
-     * @param string  $after_cursor         Return results after the given pagination cursor.
-     * @param string  $before_cursor        Return results before the given pagination cursor.
-     * @param integer $per_page             Number of results to return.
+     * @param integer $subscriber_id       Subscriber ID.
+     * @param boolean $include_total_count To include the total count of records in the response, use true.
+     * @param string  $after_cursor        Return results after the given pagination cursor.
+     * @param string  $before_cursor       Return results before the given pagination cursor.
+     * @param integer $per_page            Number of results to return.
      *
      * @see https://developers.convertkit.com/v4.html#list-tags-for-a-subscriber
      *
@@ -1967,11 +1967,11 @@ class ConvertKit_API
     /**
      * Adds total count and pagination parameters to the given array of existing API parameters.
      *
-     * @param array<string, string|integer|bool> $params                API parameters.
-     * @param boolean                            $include_total_count   Return total count of records.
-     * @param string                             $after_cursor          Return results after the given pagination cursor.
-     * @param string                             $before_cursor         Return results before the given pagination cursor.
-     * @param integer                            $per_page              Number of results to return.
+     * @param array<string, string|integer|bool> $params              API parameters.
+     * @param boolean                            $include_total_count Return total count of records.
+     * @param string                             $after_cursor        Return results after the given pagination cursor.
+     * @param string                             $before_cursor       Return results before the given pagination cursor.
+     * @param integer                            $per_page            Number of results to return.
      *
      * @since 2.0.0
      *

--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -451,15 +451,16 @@ class ConvertKit_API
     /**
      * List subscribers for a form
      *
-     * @param integer   $form_id          Form ID.
-     * @param string    $subscriber_state Subscriber State (active|bounced|cancelled|complained|inactive).
-     * @param \DateTime $created_after    Filter subscribers who have been created after this date.
-     * @param \DateTime $created_before   Filter subscribers who have been created before this date.
-     * @param \DateTime $added_after      Filter subscribers who have been added to the form after this date.
-     * @param \DateTime $added_before     Filter subscribers who have been added to the form before this date.
-     * @param string    $after_cursor     Return results after the given pagination cursor.
-     * @param string    $before_cursor    Return results before the given pagination cursor.
-     * @param integer   $per_page         Number of results to return.
+     * @param integer   $form_id                Form ID.
+     * @param string    $subscriber_state       Subscriber State (active|bounced|cancelled|complained|inactive).
+     * @param \DateTime $created_after          Filter subscribers who have been created after this date.
+     * @param \DateTime $created_before         Filter subscribers who have been created before this date.
+     * @param \DateTime $added_after            Filter subscribers who have been added to the form after this date.
+     * @param \DateTime $added_before           Filter subscribers who have been added to the form before this date.
+     * @param boolean   $include_total_count    To include the total count of records in the response, use true.
+     * @param string    $after_cursor           Return results after the given pagination cursor.
+     * @param string    $before_cursor          Return results before the given pagination cursor.
+     * @param integer   $per_page               Number of results to return.
      *
      * @see https://developers.convertkit.com/v4.html#list-subscribers-for-a-form
      *
@@ -472,6 +473,7 @@ class ConvertKit_API
         \DateTime $created_before = null,
         \DateTime $added_after = null,
         \DateTime $added_before = null,
+        bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100
@@ -495,24 +497,23 @@ class ConvertKit_API
             $options['added_before'] = $added_before->format('Y-m-d');
         }
 
-        // Build pagination parameters.
-        $options = $this->build_total_count_and_pagination_params(
-            params: $options,
-            after_cursor: $after_cursor,
-            before_cursor: $before_cursor,
-            per_page: $per_page
-        );
-
         // Send request.
         return $this->get(
             endpoint: sprintf('forms/%s/subscribers', $form_id),
-            args: $options
+            args: $this->build_total_count_and_pagination_params(
+                params: $options,
+                include_total_count: $include_total_count,
+                after_cursor: $after_cursor,
+                before_cursor: $before_cursor,
+                per_page: $per_page
+            )
         );
     }
 
     /**
      * Gets sequences
      *
+     * @param boolean $include_total_count  To include the total count of records in the response, use true.
      * @param string  $after_cursor  Return results after the given pagination cursor.
      * @param string  $before_cursor Return results before the given pagination cursor.
      * @param integer $per_page      Number of results to return.
@@ -521,11 +522,16 @@ class ConvertKit_API
      *
      * @return false|mixed
      */
-    public function get_sequences(string $after_cursor = '', string $before_cursor = '', int $per_page = 100)
-    {
+    public function get_sequences(
+        bool $include_total_count = false,
+        string $after_cursor = '',
+        string $before_cursor = '',
+        int $per_page = 100
+    ) {
         return $this->get(
             endpoint: 'sequences',
             args: $this->build_total_count_and_pagination_params(
+                include_total_count: $include_total_count,
                 after_cursor: $after_cursor,
                 before_cursor: $before_cursor,
                 per_page: $per_page
@@ -571,15 +577,16 @@ class ConvertKit_API
     /**
      * List subscribers for a sequence
      *
-     * @param integer   $sequence_id      Sequence ID.
-     * @param string    $subscriber_state Subscriber State (active|bounced|cancelled|complained|inactive).
-     * @param \DateTime $created_after    Filter subscribers who have been created after this date.
-     * @param \DateTime $created_before   Filter subscribers who have been created before this date.
-     * @param \DateTime $added_after      Filter subscribers who have been added to the form after this date.
-     * @param \DateTime $added_before     Filter subscribers who have been added to the form before this date.
-     * @param string    $after_cursor     Return results after the given pagination cursor.
-     * @param string    $before_cursor    Return results before the given pagination cursor.
-     * @param integer   $per_page         Number of results to return.
+     * @param integer   $sequence_id            Sequence ID.
+     * @param string    $subscriber_state       Subscriber State (active|bounced|cancelled|complained|inactive).
+     * @param \DateTime $created_after          Filter subscribers who have been created after this date.
+     * @param \DateTime $created_before         Filter subscribers who have been created before this date.
+     * @param \DateTime $added_after            Filter subscribers who have been added to the form after this date.
+     * @param \DateTime $added_before           Filter subscribers who have been added to the form before this date.
+     * @param boolean   $include_total_count    To include the total count of records in the response, use true.
+     * @param string    $after_cursor           Return results after the given pagination cursor.
+     * @param string    $before_cursor          Return results before the given pagination cursor.
+     * @param integer   $per_page               Number of results to return.
      *
      * @see https://developers.convertkit.com/v4.html#list-subscribers-for-a-sequence
      *
@@ -592,6 +599,7 @@ class ConvertKit_API
         \DateTime $created_before = null,
         \DateTime $added_after = null,
         \DateTime $added_before = null,
+        bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100
@@ -615,18 +623,15 @@ class ConvertKit_API
             $options['added_before'] = $added_before->format('Y-m-d');
         }
 
-        // Build pagination parameters.
-        $options = $this->build_total_count_and_pagination_params(
-            params: $options,
-            after_cursor: $after_cursor,
-            before_cursor: $before_cursor,
-            per_page: $per_page
-        );
-
         // Send request.
         return $this->get(
             endpoint: sprintf('sequences/%s/subscribers', $sequence_id),
-            args: $options
+            args: $this->build_total_count_and_pagination_params(
+                params: $options,
+                after_cursor: $after_cursor,
+                before_cursor: $before_cursor,
+                per_page: $per_page
+            )
         );
     }
 
@@ -786,15 +791,16 @@ class ConvertKit_API
     /**
      * List subscribers for a tag
      *
-     * @param integer   $tag_id           Tag ID.
-     * @param string    $subscriber_state Subscriber State (active|bounced|cancelled|complained|inactive).
-     * @param \DateTime $created_after    Filter subscribers who have been created after this date.
-     * @param \DateTime $created_before   Filter subscribers who have been created before this date.
-     * @param \DateTime $tagged_after     Filter subscribers who have been tagged after this date.
-     * @param \DateTime $tagged_before    Filter subscribers who have been tagged before this date.
-     * @param string    $after_cursor     Return results after the given pagination cursor.
-     * @param string    $before_cursor    Return results before the given pagination cursor.
-     * @param integer   $per_page         Number of results to return.
+     * @param integer   $tag_id                 Tag ID.
+     * @param string    $subscriber_state       Subscriber State (active|bounced|cancelled|complained|inactive).
+     * @param \DateTime $created_after          Filter subscribers who have been created after this date.
+     * @param \DateTime $created_before         Filter subscribers who have been created before this date.
+     * @param \DateTime $tagged_after           Filter subscribers who have been tagged after this date.
+     * @param \DateTime $tagged_before          Filter subscribers who have been tagged before this date.
+     * @param boolean   $include_total_count    To include the total count of records in the response, use true.
+     * @param string    $after_cursor           Return results after the given pagination cursor.
+     * @param string    $before_cursor          Return results before the given pagination cursor.
+     * @param integer   $per_page               Number of results to return.
      *
      * @see https://developers.convertkit.com/v4.html#list-subscribers-for-a-tag
      *
@@ -807,6 +813,7 @@ class ConvertKit_API
         \DateTime $created_before = null,
         \DateTime $tagged_after = null,
         \DateTime $tagged_before = null,
+        bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
         int $per_page = 100
@@ -830,18 +837,16 @@ class ConvertKit_API
             $options['tagged_before'] = $tagged_before->format('Y-m-d');
         }
 
-        // Build pagination parameters.
-        $options = $this->build_total_count_and_pagination_params(
-            params: $options,
-            after_cursor: $after_cursor,
-            before_cursor: $before_cursor,
-            per_page: $per_page
-        );
-
         // Send request.
         return $this->get(
             endpoint: sprintf('tags/%s/subscribers', $tag_id),
-            args: $options
+            args: $this->build_total_count_and_pagination_params(
+                params: $options,
+                include_total_count: $include_total_count,
+                after_cursor: $after_cursor,
+                before_cursor: $before_cursor,
+                per_page: $per_page
+            )
         );
     }
 
@@ -1056,19 +1061,16 @@ class ConvertKit_API
             $options['sort_order'] = $sort_order;
         }
 
-        // Build pagination parameters.
-        $options = $this->build_total_count_and_pagination_params(
-            params: $options,
-            include_total_count: $include_total_count,
-            after_cursor: $after_cursor,
-            before_cursor: $before_cursor,
-            per_page: $per_page
-        );
-
         // Send request.
         return $this->get(
             endpoint: 'subscribers',
-            args: $options
+            args: $this->build_total_count_and_pagination_params(
+                params: $options,
+                include_total_count: $include_total_count,
+                after_cursor: $after_cursor,
+                before_cursor: $before_cursor,
+                per_page: $per_page
+            )
         );
     }
 

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -757,6 +757,30 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that get_form_subscriptions() returns the expected data
+     * when the total count is included.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetFormSubscriptionsWithTotalCount()
+    {
+        $result = $this->api->get_form_subscriptions(
+            form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+            include_total_count: true
+        );
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
+
+        // Assert total count is included.
+        $this->assertArrayHasKey('total_count', get_object_vars($result->pagination));
+        $this->assertGreaterThan(0, $result->pagination->total_count);
+    }
+
+    /**
+     * Test that get_form_subscriptions() returns the expected data
      * when a valid Form ID is specified and the subscription status
      * is cancelled.
      *
@@ -1023,6 +1047,29 @@ class ConvertKitAPITest extends TestCase
     }
 
     /**
+     * Test that get_sequences() returns the expected data
+     * when the total count is included.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetSequencesWithTotalCount()
+    {
+        $result = $this->api->get_sequences(
+            include_total_count: true
+        );
+
+        // Assert sequences and pagination exist.
+        $this->assertDataExists($result, 'sequences');
+        $this->assertPaginationExists($result);
+
+        // Assert total count is included.
+        $this->assertArrayHasKey('total_count', get_object_vars($result->pagination));
+        $this->assertGreaterThan(0, $result->pagination->total_count);
+    }
+
+    /**
      * Test that get_sequences() returns the expected data when
      * pagination parameters and per_page limits are specified.
      *
@@ -1203,6 +1250,30 @@ class ConvertKitAPITest extends TestCase
         // Assert subscribers and pagination exist.
         $this->assertDataExists($result, 'subscribers');
         $this->assertPaginationExists($result);
+    }
+
+    /**
+     * Test that get_sequence_subscriptions() returns the expected data
+     * when the total count is included.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetSequencesWithTotalCount()
+    {
+        $result = $this->api->get_sequence_subscriptions(
+            sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+            include_total_count: true
+        );
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
+
+        // Assert total count is included.
+        $this->assertArrayHasKey('total_count', get_object_vars($result->pagination));
+        $this->assertGreaterThan(0, $result->pagination->total_count);
     }
 
     /**
@@ -1468,6 +1539,29 @@ class ConvertKitAPITest extends TestCase
         $this->assertArrayHasKey('id', $tag);
         $this->assertArrayHasKey('name', $tag);
         $this->assertArrayHasKey('created_at', $tag);
+    }
+
+    /**
+     * Test that get_tags() returns the expected data
+     * when the total count is included.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetTagsWithTotalCount()
+    {
+        $result = $this->api->get_tags(
+            include_total_count: true
+        );
+
+        // Assert tags and pagination exist.
+        $this->assertDataExists($result, 'tags');
+        $this->assertPaginationExists($result);
+
+        // Assert total count is included.
+        $this->assertArrayHasKey('total_count', get_object_vars($result->pagination));
+        $this->assertGreaterThan(0, $result->pagination->total_count);
     }
 
     /**
@@ -1950,6 +2044,30 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that get_tag_subscriptions() returns the expected data
+     * when the total count is included.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetTagSubscriptionsWithTotalCount()
+    {
+        $result = $this->api->get_tag_subscriptions(
+            tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+            include_total_count: true
+        );
+
+        // Assert tags and pagination exist.
+        $this->assertDataExists($result, 'tags');
+        $this->assertPaginationExists($result);
+
+        // Assert total count is included.
+        $this->assertArrayHasKey('total_count', get_object_vars($result->pagination));
+        $this->assertGreaterThan(0, $result->pagination->total_count);
+    }
+
+    /**
+     * Test that get_tag_subscriptions() returns the expected data
      * when a valid Tag ID is specified and the subscription status
      * is bounced.
      *
@@ -2344,6 +2462,29 @@ class ConvertKitAPITest extends TestCase
         // Assert subscribers and pagination exist.
         $this->assertDataExists($result, 'subscribers');
         $this->assertPaginationExists($result);
+    }
+
+    /**
+     * Test that get_subscribers() returns the expected data
+     * when the total count is included.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetSubscribersWithTotalCount()
+    {
+        $result = $this->api->get_subscribers(
+            include_total_count: true
+        );
+
+        // Assert subscribers and pagination exist.
+        $this->assertDataExists($result, 'subscribers');
+        $this->assertPaginationExists($result);
+
+        // Assert total count is included.
+        $this->assertArrayHasKey('total_count', get_object_vars($result->pagination));
+        $this->assertGreaterThan(0, $result->pagination->total_count);
     }
 
     /**
@@ -3205,6 +3346,30 @@ class ConvertKitAPITest extends TestCase
         // Assert tags and pagination exist.
         $this->assertDataExists($result, 'tags');
         $this->assertPaginationExists($result);
+    }
+
+    /**
+     * Test that get_subscriber_tags() returns the expected data
+     * when the total count is included.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testGetSubscriberTagsWithTotalCount()
+    {
+        $result = $this->api->get_subscriber_tags(
+            subscriber_id: (int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
+            include_total_count: true
+        );
+
+        // Assert tags and pagination exist.
+        $this->assertDataExists($result, 'tags');
+        $this->assertPaginationExists($result);
+
+        // Assert total count is included.
+        $this->assertArrayHasKey('total_count', get_object_vars($result->pagination));
+        $this->assertGreaterThan(0, $result->pagination->total_count);
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds support for `include_total_count` for existing PRs that were created prior to this parameter being added to the v4 API.

Separate PR for `forms` endpoint to follow to include both this and pagination support, which is currently missing.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)