### PR TITLE
v4 API: Purchases: SKU and Required / Optional Fields

### DIFF
--- a/src/ConvertKit_API.php
+++ b/src/ConvertKit_API.php
@@ -1750,15 +1750,16 @@ class ConvertKit_API
      *
      * @param string                         $email_address    Email Address.
      * @param string                         $transaction_id   Transaction ID.
+     * @param array<string,int|float|string> $products         Products.
+     * @param string                         $currency         ISO Currency Code.
+     * @param string                         $first_name       First Name.
      * @param string                         $status           Order Status.
      * @param float                          $subtotal         Subtotal.
      * @param float                          $tax              Tax.
      * @param float                          $shipping         Shipping.
      * @param float                          $discount         Discount.
      * @param float                          $total            Total.
-     * @param string                         $currency         ISO Currency Code.
      * @param \DateTime                      $transaction_time Transaction date and time.
-     * @param array<string,int|float|string> $products         Products.
      *
      * @see https://developers.convertkit.com/v4.html#create-a-purchase
      *
@@ -1767,30 +1768,47 @@ class ConvertKit_API
     public function create_purchase(
         string $email_address,
         string $transaction_id,
-        string $status,
+        array $products,
+        string $currency = 'USD',
+        string $first_name = null,
+        string $status = null,
         float $subtotal = 0,
         float $tax = 0,
         float $shipping = 0,
         float $discount = 0,
         float $total = 0,
-        string $currency = 'usd',
-        \DateTime $transaction_time = null,
-        array $products = []
+        \DateTime $transaction_time = null
     ) {
         // Build parameters.
         $options = [
+            // Required fields.
             'email_address'    => $email_address,
             'transaction_id'   => $transaction_id,
+            'products'         => $products,
+            'currency'         => $currency, // Required, but if not provided, API will default to USD.
+
+            // Optional fields.
+            'first_name'       => $first_name,
             'status'           => $status,
             'subtotal'         => $subtotal,
             'tax'              => $tax,
             'shipping'         => $shipping,
             'discount'         => $discount,
             'total'            => $total,
-            'currency'         => $currency,
             'transaction_time' => (!is_null($transaction_time) ? $transaction_time->format('Y-m-d H:i:s') : ''),
-            'products'         => $products,
         ];
+
+        // Iterate through options, removing blank and null entries.
+        foreach ($options as $key => $value) {
+            if (is_null($value)) {
+                unset($options[$key]);
+                continue;
+            }
+
+            if (is_string($value) && strlen($value) === 0) {
+                unset($options[$key]);
+            }
+        }
 
         return $this->post('purchases', $options);
     }
@@ -2015,8 +2033,8 @@ class ConvertKit_API
     /**
      * Performs a POST request to the API.
      *
-     * @param string                                                                                                $endpoint API Endpoint.
-     * @param array<string, bool|integer|float|string|array<int|string, float|integer|string|array<string|string>>> $args     Request arguments.
+     * @param string                                                                                                     $endpoint API Endpoint.
+     * @param array<string, bool|integer|float|string|null|array<int|string, float|integer|string|array<string|string>>> $args     Request arguments.
      *
      * @return false|mixed
      */
@@ -2054,9 +2072,9 @@ class ConvertKit_API
     /**
      * Performs an API request using Guzzle.
      *
-     * @param string                                                                                                $endpoint API Endpoint.
-     * @param string                                                                                                $method   Request method.
-     * @param array<string, bool|integer|float|string|array<int|string, float|integer|string|array<string|string>>> $args     Request arguments.
+     * @param string                                                                                                     $endpoint API Endpoint.
+     * @param string                                                                                                     $method   Request method.
+     * @param array<string, bool|integer|float|string|null|array<int|string, float|integer|string|array<string|string>>> $args     Request arguments.
      *
      * @throws \Exception If JSON encoding arguments failed.
      *

--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -4226,19 +4226,14 @@ class ConvertKitAPITest extends TestCase
     public function testCreatePurchase()
     {
         $purchase = $this->api->create_purchase(
+            // Required fields.
             email_address: $this->generateEmailAddress(),
             transaction_id: str_shuffle('wfervdrtgsdewrafvwefds'),
-            status: 'paid',
-            subtotal: 20.00,
-            tax: 2.00,
-            shipping: 2.00,
-            discount: 3.00,
-            total: 21.00,
             currency: 'usd',
-            transaction_time: new DateTime('now'),
             products: [
                 [
                     'name' => 'Floppy Disk (512k)',
+                    'sku' => '7890-ijkl',
                     'pid' => 9999,
                     'lid' => 7777,
                     'quantity' => 2,
@@ -4246,12 +4241,22 @@ class ConvertKitAPITest extends TestCase
                 ],
                 [
                     'name' => 'Telephone Cord (data)',
+                    'sku' => 'mnop-1234',
                     'pid' => 5555,
                     'lid' => 7778,
                     'quantity' => 1,
                     'unit_price' => 10.00,
                 ],
             ],
+            // Optional fields.
+            first_name: 'Tim',
+            status: 'paid',
+            subtotal: 20.00,
+            tax: 2.00,
+            shipping: 2.00,
+            discount: 3.00,
+            total: 21.00,
+            transaction_time: new DateTime('now'),
         );
 
         $this->assertInstanceOf('stdClass', $purchase);
@@ -4260,19 +4265,76 @@ class ConvertKitAPITest extends TestCase
 
     /**
      * Test that create_purchase() throws a ClientException when an invalid
-     * purchase data is specified.
+     * email address is specified.
      *
-     * @since   1.0.0
+     * @since   2.0.0
      *
      * @return void
      */
-    public function testCreatePurchaseWithInvalidData()
+    public function testCreatePurchaseWithInvalidEmailAddress()
     {
         $this->expectException(ClientException::class);
         $this->api->create_purchase(
             email_address: 'not-an-email-address',
             transaction_id: str_shuffle('wfervdrtgsdewrafvwefds'),
-            status: 'paid'
+            currency: 'usd',
+            products: [
+                [
+                    'name' => 'Floppy Disk (512k)',
+                    'sku' => '7890-ijkl',
+                    'pid' => 9999,
+                    'lid' => 7777,
+                    'quantity' => 2,
+                    'unit_price' => 5.00,
+                ],
+            ],
+        );
+    }
+
+    /**
+     * Test that create_purchase() throws a ClientException when a blank
+     * transaction ID is specified.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testCreatePurchaseWithBlankTransactionID()
+    {
+        $this->expectException(ClientException::class);
+        $this->api->create_purchase(
+            email_address: $this->generateEmailAddress(),
+            transaction_id: '',
+            currency: 'usd',
+            products: [
+                [
+                    'name' => 'Floppy Disk (512k)',
+                    'sku' => '7890-ijkl',
+                    'pid' => 9999,
+                    'lid' => 7777,
+                    'quantity' => 2,
+                    'unit_price' => 5.00,
+                ],
+            ],
+        );
+    }
+
+    /**
+     * Test that create_purchase() throws a ClientException when no products
+     * are specified.
+     *
+     * @since   2.0.0
+     *
+     * @return void
+     */
+    public function testCreatePurchaseWithNoProducts()
+    {
+        $this->expectException(ClientException::class);
+        $this->api->create_purchase(
+            email_address: $this->generateEmailAddress(),
+            transaction_id: str_shuffle('wfervdrtgsdewrafvwefds'),
+            currency: 'usd',
+            products: [],
         );
     }
 


### PR DESCRIPTION
## Summary

- Adds `sku` to the `products` array for testing, as this is supported in the API ([docs](https://developers.convertkit.com/v4.html#create-a-purchase), [slack](https://n7studios-workspace.slack.com/archives/C02KFR6N1GF/p1711661766953569?thread_ts=1711640295.025739&cid=C02KFR6N1GF))
- Reorders `create_purchase` method parameters to ensure required parameters listed first
- Removes blank and null parameters prior to calling the create purchase endpoint

## Testing

- `testCreatePurchaseWithInvalidEmailAddress`: Test that a `ClientException` is thrown when an invalid email address is specified
- `testCreatePurchaseWithBlankTransactionID`: Test that a `ClientException` is thrown when no transaction ID defined
- `testCreatePurchaseWithNoProducts`: Test that a `ClientException` is thrown when no `products` are defined

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)