### PR TITLE
v4 API: Mock Create Tag Tests

### DIFF
--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -1627,9 +1627,24 @@ class ConvertKitAPITest extends TestCase
     public function testCreateTag()
     {
         $tagName = 'Tag Test ' . mt_rand();
+
+        // Add mock handler for this API request, as the API doesn't provide
+        // a method to delete tags to cleanup the test.
+        $this->api = $this->mockResponse(
+            api: $this->api,
+            responseBody: [
+                'tag' => [
+                    'id' => 12345,
+                    'name' => $tagName,
+                    'created_at' => date('Y-m-d') . 'T' . date('H:i:s') . 'Z',
+                ],
+            ]
+        );
+
+        // Send request.
         $result = $this->api->create_tag($tagName);
 
-        // Convert to array to check for keys, as assertObjectHasAttribute() will be deprecated in PHPUnit 10.
+        // Assert response contains correct data.
         $tag = get_object_vars($result->tag);
         $this->assertArrayHasKey('id', $tag);
         $this->assertArrayHasKey('name', $tag);
@@ -1678,6 +1693,28 @@ class ConvertKitAPITest extends TestCase
             'Tag Test ' . mt_rand(),
             'Tag Test ' . mt_rand(),
         ];
+
+        // Add mock handler for this API request, as the API doesn't provide
+        // a method to delete tags to cleanup the test.
+        $this->api = $this->mockResponse(
+            api: $this->api,
+            responseBody: [
+                'tags' => [
+                    [
+                        'id' => 12345,
+                        'name' => $tagNames[0],
+                        'created_at' => date('Y-m-d') . 'T' . date('H:i:s') . 'Z',
+                    ],
+                    [
+                        'id' => 23456,
+                        'name' => $tagNames[1],
+                        'created_at' => date('Y-m-d') . 'T' . date('H:i:s') . 'Z',
+                    ],
+                ],
+                'failures' => [],
+            ]
+        );
+
         $result = $this->api->create_tags($tagNames);
 
         // Assert no failures.


### PR DESCRIPTION
## Summary

Mocks responses for `testCreateTag` and `testCreateTags`, with response objects matching those from the v4 API.

This prevents the ConvertKit account having hundreds of tags created across multiple tests and PRs, due to there being no API method to delete tags.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)