### PR TITLE
v4 API: Improve Subscriber Tests

### DIFF
--- a/tests/ConvertKitAPITest.php
+++ b/tests/ConvertKitAPITest.php
@@ -1134,16 +1134,26 @@ class ConvertKitAPITest extends TestCase
      */
     public function testAddSubscriberToSequenceByEmail()
     {
+        // Create subscriber.
+        $emailAddress = $this->generateEmailAddress();
+        $subscriber = $this->api->create_subscriber(
+            email_address: $emailAddress
+        );
+
+        // Set subscriber_id to ensure subscriber is unsubscribed after test.
+        $this->subscriber_ids[] = $subscriber->subscriber->id;
+
+        // Add subscriber to sequence.
         $result = $this->api->add_subscriber_to_sequence_by_email(
             sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-            email_address: $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
+            email_address: $emailAddress
         );
         $this->assertInstanceOf('stdClass', $result);
         $this->assertArrayHasKey('subscriber', get_object_vars($result));
         $this->assertArrayHasKey('id', get_object_vars($result->subscriber));
         $this->assertEquals(
             get_object_vars($result->subscriber)['email_address'],
-            $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
+            $emailAddress
         );
     }
 
@@ -1190,14 +1200,23 @@ class ConvertKitAPITest extends TestCase
      */
     public function testAddSubscriberToSequence()
     {
+        // Create subscriber.
+        $subscriber = $this->api->create_subscriber(
+            email_address: $this->generateEmailAddress()
+        );
+
+        // Set subscriber_id to ensure subscriber is unsubscribed after test.
+        $this->subscriber_ids[] = $subscriber->subscriber->id;
+
+        // Add subscriber to sequence.
         $result = $this->api->add_subscriber_to_sequence(
             sequence_id: (int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-            subscriber_id: $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
+            subscriber_id: $subscriber->subscriber->id
         );
         $this->assertInstanceOf('stdClass', $result);
         $this->assertArrayHasKey('subscriber', get_object_vars($result));
         $this->assertArrayHasKey('id', get_object_vars($result->subscriber));
-        $this->assertEquals(get_object_vars($result->subscriber)['id'], $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+        $this->assertEquals(get_object_vars($result->subscriber)['id'], $subscriber->subscriber->id);
     }
 
     /**
@@ -2388,14 +2407,27 @@ class ConvertKitAPITest extends TestCase
      */
     public function testAddSubscriberToFormByEmail()
     {
+        // Create subscriber.
+        $emailAddress = $this->generateEmailAddress();
+        $subscriber = $this->api->create_subscriber(
+            email_address: $emailAddress
+        );
+
+        // Set subscriber_id to ensure subscriber is unsubscribed after test.
+        $this->subscriber_ids[] = $subscriber->subscriber->id;
+
+        // Add subscriber to form.
         $result = $this->api->add_subscriber_to_form_by_email(
             form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
-            email_address: $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
+            email_address: $emailAddress
         );
         $this->assertInstanceOf('stdClass', $result);
         $this->assertArrayHasKey('subscriber', get_object_vars($result));
         $this->assertArrayHasKey('id', get_object_vars($result->subscriber));
-        $this->assertEquals(get_object_vars($result->subscriber)['id'], $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+        $this->assertEquals(
+            get_object_vars($result->subscriber)['email_address'],
+            $emailAddress
+        );
     }
 
     /**
@@ -2441,14 +2473,22 @@ class ConvertKitAPITest extends TestCase
      */
     public function testAddSubscriberToForm()
     {
+        // Create subscriber.
+        $subscriber = $this->api->create_subscriber(
+            email_address: $this->generateEmailAddress()
+        );
+
+        // Set subscriber_id to ensure subscriber is unsubscribed after test.
+        $this->subscriber_ids[] = $subscriber->subscriber->id;
+
         $result = $this->api->add_subscriber_to_form(
             form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
-            subscriber_id: $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
+            subscriber_id: $subscriber->subscriber->id
         );
         $this->assertInstanceOf('stdClass', $result);
         $this->assertArrayHasKey('subscriber', get_object_vars($result));
         $this->assertArrayHasKey('id', get_object_vars($result->subscriber));
-        $this->assertEquals(get_object_vars($result->subscriber)['id'], $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+        $this->assertEquals(get_object_vars($result->subscriber)['id'], $subscriber->subscriber->id);
     }
 
     /**


### PR DESCRIPTION
## Summary

Create a subscriber before subscribing them to a resource, such as a form, tag or sequence (vs. using an existing subscriber that is already subscribed to a resource), to improve the accuracy of tests.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)